### PR TITLE
Address #19: Fix a few of the Firefox issues

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -32,12 +32,12 @@ body {
         top: 0;
         bottom: 0;
         display: flex;
-        flex-direction: column; 
+        flex-direction: column;
         color: $theme-primary-foreground;
     }
 
     &-title__button {
-        background: $theme-application-title-background; 
+        background: $theme-application-title-background;
         color: $theme-application-title-foreground;
         padding: 10px;
     }
@@ -131,6 +131,7 @@ body {
                 display: flex;
                 flex: 1;
                 flex-direction: row;
+                overflow: hidden;
             }
 
             &-panel {

--- a/sass/components/canvas/attribute_editor.scss
+++ b/sass/components/canvas/attribute_editor.scss
@@ -691,6 +691,9 @@
                 display: flex;
                 flex-direction: row;
                 width: 100%;
+                &-input {
+                    width: 100%;
+                }
                 & > *:not(:first-child) {
                     flex-shrink: 0;
                     flex-grow: 0;

--- a/sass/components/file_view.scss
+++ b/sass/components/file_view.scss
@@ -36,6 +36,7 @@
     min-width: 600px;
     display: flex;
     flex-direction: row;
+    overflow: hidden;
 
     &-tabs {
         flex-shrink: 0;

--- a/sass/components/minimizable_panel.scss
+++ b/sass/components/minimizable_panel.scss
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;
     flex: 1;
+    overflow: hidden;
 
     $header-height: 28px;
 
@@ -49,6 +50,7 @@
         }
         &.minimizable-pane-autosize {
             flex: 1;
+            overflow: hidden;
             & > .content {
                 flex: 1;
                 overflow-y: scroll;

--- a/sass/components/popup.scss
+++ b/sass/components/popup.scss
@@ -147,6 +147,7 @@
             flex: 1;
             display: flex;
             flex-direction: column;
+            overflow: hidden;
         }
     }
 

--- a/src/app/views/panels/widgets/controls.tsx
+++ b/src/app/views/panels/widgets/controls.tsx
@@ -242,15 +242,17 @@ export class InputNumber extends React.Component<InputNumberProps, {}> {
   public render() {
     return (
       <span className="charticulator__widget-control-input-number">
-        <InputText
-          ref={e => (this.textInput = e)}
-          placeholder={this.props.placeholder}
-          defaultValue={this.formatNumber(this.props.defaultValue)}
-          onEnter={str => {
-            const num = this.parseNumber(str);
-            return this.reportValue(num);
-          }}
-        />
+        <div className="charticulator__widget-control-input-number-input">
+          <InputText
+            ref={e => (this.textInput = e)}
+            placeholder={this.props.placeholder}
+            defaultValue={this.formatNumber(this.props.defaultValue)}
+            onEnter={str => {
+              const num = this.parseNumber(str);
+              return this.reportValue(num);
+            }}
+          />
+        </div>
         {this.props.showSlider ? this.renderSlider() : null}
         {this.props.showUpdown ? this.renderUpdown() : null}
       </span>


### PR DESCRIPTION
- Fix slider for input fields that are misplaced
- Fix scroll bars in New/Open/SaveAs/Export panels
- Fix scroll bars in attribute and layer panels
- Fix the bar under the chart canvas
- Probably fix unwanted auto re-centering of the chart canvas may happen when working in the glyph editor

Note that these also happens in the Edge browser, it seems like an explicit `overview: hidden` is necessary in these browsers for flex elements that contain oversized elements, whereas in the Chrome/Webkit browsers, it's not.