### PR TITLE
More expressive data mapping to text

### DIFF
--- a/build.js
+++ b/build.js
@@ -81,7 +81,7 @@ let COMMANDS = {
 
     // Compile the PEGJS parser
     pegjs: [
-        "pegjs --format commonjs --allowed-start-rules start -o dist/scripts/core/expression/parser.js src/core/expression/parser.pegjs",
+        "pegjs --format commonjs --allowed-start-rules start,start_text -o dist/scripts/core/expression/parser.js src/core/expression/parser.pegjs",
     ],
 
     // Compile TypeScript

--- a/src/app/stores/chart.ts
+++ b/src/app/stores/chart.ts
@@ -445,12 +445,21 @@ export class ChartStore extends BaseStore {
           scale: inferred
         } as Specification.ScaleMapping;
       } else {
+        if (action.valueType == "number" && action.attributeType == "string") {
+          action.mark.mappings[action.attribute] = {
+            type: "text",
+            textExpression: new Expression.TextExpression([
+              { expression: Expression.parse(action.expression), format: ".1f" }
+            ]).toString()
+          } as Specification.TextMapping;
+        }
         if (action.valueType == "string" && action.attributeType == "string") {
           action.mark.mappings[action.attribute] = {
-            type: "scale",
-            expression: action.expression,
-            valueType: action.valueType
-          } as Specification.ScaleMapping;
+            type: "text",
+            textExpression: new Expression.TextExpression([
+              { expression: Expression.parse(action.expression) }
+            ]).toString()
+          } as Specification.TextMapping;
         }
       }
 
@@ -1330,9 +1339,9 @@ export class ChartStore extends BaseStore {
       scaleClassID = `scale.categorical`;
     }
     // Number to string: number formatting
-    if (valueType == "number" && outputType == "string") {
-      scaleClassID = `scale.format`;
-    }
+    // if (valueType == "number" && outputType == "string") {
+    //   scaleClassID = `scale.format`;
+    // }
     if (
       (valueType == "number" || valueType == "integer") &&
       outputType == "color"

--- a/src/app/views/panels/widgets/mapping_editor.tsx
+++ b/src/app/views/panels/widgets/mapping_editor.tsx
@@ -17,7 +17,8 @@ import {
   colorToHTMLColorHEX,
   colorFromHTMLColor,
   EventSubscription,
-  EventEmitter
+  EventEmitter,
+  Expression
 } from "../../../../core";
 import {
   SVGImageIcon,
@@ -351,6 +352,24 @@ export class MappingEditor extends React.Component<
           const valueMapping = mapping as Specification.ValueMapping;
           return this.renderValueEditor(valueMapping.value);
         }
+        case "text": {
+          const textMapping = mapping as Specification.TextMapping;
+          return (
+            <InputText
+              defaultValue={textMapping.textExpression}
+              onEnter={newValue => {
+                textMapping.textExpression = Expression.parseTextExpression(
+                  newValue
+                ).toString();
+                this.props.parent.onEditMappingHandler(
+                  this.props.attribute,
+                  textMapping
+                );
+                return true;
+              }}
+            />
+          );
+        }
         case "scale": {
           const scaleMapping = mapping as Specification.ScaleMapping;
           if (scaleMapping.scale) {
@@ -399,7 +418,7 @@ export class MappingEditor extends React.Component<
             );
           } else {
             return (
-              <span className="el-mapping-scale">
+              <span>
                 <span className="el-mapping-scale-scale is-left">=</span>
                 <svg width={6} height={20}>
                   <path d="M3.2514,10A17.37314,17.37314,0,0,1,6,0H0V20H6A17.37342,17.37342,0,0,1,3.2514,10Z" />

--- a/src/app/views/panels/widgets/mapping_editor.tsx
+++ b/src/app/views/panels/widgets/mapping_editor.tsx
@@ -418,7 +418,7 @@ export class MappingEditor extends React.Component<
             );
           } else {
             return (
-              <span>
+              <span className="el-mapping-scale">
                 <span className="el-mapping-scale-scale is-left">=</span>
                 <svg width={6} height={20}>
                   <path d="M3.2514,10A17.37314,17.37314,0,0,1,6,0H0V20H6A17.37342,17.37342,0,0,1,3.2514,10Z" />

--- a/src/core/expression/helpers.ts
+++ b/src/core/expression/helpers.ts
@@ -8,10 +8,9 @@ import {
   NumberValue,
   Operator,
   StringValue,
-  Variable
+  Variable,
+  TextExpression
 } from "./classes";
-
-import { parse } from "./parser";
 
 export function variable(name: string): Variable {
   return new Variable(name);
@@ -68,16 +67,28 @@ export function date(v: Date) {
 
 export class ExpressionCache {
   private items = new Map<string, Expression>();
+  private textItems = new Map<string, TextExpression>();
   public clear() {
     this.items.clear();
+    this.textItems.clear();
   }
 
   public parse(expr: string): Expression {
     if (this.items.has(expr)) {
       return this.items.get(expr);
     } else {
-      const result = parse(expr);
+      const result = Expression.Parse(expr);
       this.items.set(expr, result);
+      return result;
+    }
+  }
+
+  public parseTextExpression(expr: string): TextExpression {
+    if (this.textItems.has(expr)) {
+      return this.textItems.get(expr);
+    } else {
+      const result = TextExpression.Parse(expr);
+      this.textItems.set(expr, result);
       return result;
     }
   }

--- a/src/core/expression/index.ts
+++ b/src/core/expression/index.ts
@@ -1,5 +1,9 @@
+import { Expression, TextExpression } from "./classes";
+
 export {
   Expression,
+  TextExpression,
+  TextExpressionPart,
   Context,
   ShadowContext,
   SimpleContext,
@@ -12,7 +16,16 @@ export {
   StringValue,
   DateValue
 } from "./classes";
-export { SyntaxError, parse } from "./parser";
+
+export { SyntaxError } from "./parser";
+
+export function parse(str: string): Expression {
+  return Expression.Parse(str);
+}
+
+export function parseTextExpression(str: string): TextExpression {
+  return TextExpression.Parse(str);
+}
 
 export {
   variable,

--- a/src/core/expression/intrinsics.ts
+++ b/src/core/expression/intrinsics.ts
@@ -1,4 +1,5 @@
 import { timeFormat } from "d3-time-format";
+import { format } from "d3-format";
 import { ValueType } from "./classes";
 import { fields } from "./helpers";
 
@@ -166,6 +167,10 @@ intrinsics.date = {
   second: timeFormat("%S"), // second as a decimal number [00,61].
 
   timestamp: (d: Date) => d.getTime() / 1000
+};
+
+intrinsics.format = (value: number, spec: string) => {
+  return format(spec)(value);
 };
 
 // JSON format

--- a/src/core/expression/parser.d.ts
+++ b/src/core/expression/parser.d.ts
@@ -1,6 +1,6 @@
 // Declaration of the generated parser code
 
-import { Expression } from "./classes";
+import { Expression, TextExpression } from "./classes";
 export declare class Location {
   public offset: number;
   public line: number;
@@ -27,5 +27,5 @@ export declare class SyntaxError {
 
 export declare function parse(
   input: string,
-  options?: { [name: string]: string }
-): Expression;
+  options?: { startRule: "start" | "start_text" }
+): Expression | TextExpression;

--- a/src/core/expression/parser.pegjs
+++ b/src/core/expression/parser.pegjs
@@ -32,6 +32,18 @@
 start
   = expression
 
+start_text
+  = parts:text_part*
+    { return new Expression.TextExpression(parts); }
+
+text_part
+  = "${" expr:expression "}{" sp format:[0-9a-z\.]+ sp "}"
+    { return { expression: expr, format: flatten(format) }; }
+  / "${" expr:expression "}"
+    { return { expression: expr }; }
+  / str:[^$]+
+    { return { string: flatten(str) }; }
+
 expression
   = sp expr:level_expression sp
     { return expr; }

--- a/src/core/solver/solver.ts
+++ b/src/core/solver/solver.ts
@@ -104,6 +104,15 @@ export class BaseSolver {
           }
         }
         break;
+      case "text":
+        {
+          const textMapping = mapping as Specification.TextMapping;
+          const expr = this.expressionCache.parseTextExpression(
+            textMapping.textExpression
+          );
+          attrs[attr] = expr.getValue(rowContext);
+        }
+        break;
       case "value":
         {
           const valueMapping = mapping as Specification.ValueMapping;

--- a/src/core/specification/index.ts
+++ b/src/core/specification/index.ts
@@ -77,6 +77,12 @@ export interface ScaleMapping extends Mapping {
   scale?: string;
 }
 
+/** Text mapping: map data to text */
+export interface TextMapping extends Mapping {
+  type: "text";
+  textExpression: string;
+}
+
 // /** Variable mapping: use a shared variable */
 // export interface VariableMapping extends Mapping {
 //     type: "variable";

--- a/src/tests/expression.ts
+++ b/src/tests/expression.ts
@@ -67,3 +67,38 @@ describe("Expression", () => {
     });
   });
 });
+
+describe("Text Expression", () => {
+  const test_cases: Array<[string, any]> = [
+    [
+      "Hello World, Temperature is ${Temperature}{.1f} degree",
+      "Hello World, Temperature is 70.0 degree"
+    ]
+  ];
+  const context = new Expression.SimpleContext();
+  context.variables = {
+    Temperature: 70
+  };
+
+  it("getValue", () => {
+    test_cases.forEach(ci => {
+      const expr = ci[0];
+      const expected = ci[1];
+      const e = Expression.parseTextExpression(expr);
+      const returned = e.getValue(context);
+      expect(returned).deep.equals(expected, expr);
+    });
+  });
+
+  it("toString", () => {
+    test_cases.forEach(ci => {
+      const expr = ci[0];
+      const expected = ci[1];
+      const e = Expression.parseTextExpression(expr);
+      const es = e.toString();
+      const ep = Expression.parseTextExpression(es);
+      const epreturned = e.getValue(context);
+      expect(epreturned).deep.equals(expected, expr);
+    });
+  });
+});


### PR DESCRIPTION
Allow the use of `Prefix ${ColumnName} Suffix` expression to format text, any expression can be used inside `${}`