### PR TITLE
Support floating panels

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -181,24 +181,9 @@ body {
             }
         }
     }
-}
 
-.mark-editor-single-view {
-    width: 300px;
-
-    .mark-view-container {
-        background: white;
+    &__floating-panels {
+        position: absolute;
+        left: 0; top: 0;
     }
-}
-
-.chart-editor-canvas-view {
-    background: white;
-    flex: 1;
-    overflow: hidden;
-}
-
-.chart-editor-view {
-    display: flex;
-    flex: 1;
-    flex-direction: column;
 }

--- a/sass/components/canvas/canvas.scss
+++ b/sass/components/canvas/canvas.scss
@@ -1,4 +1,26 @@
 @import "attribute_editor.scss";
+.mark-editor-view {
+    flex: 1 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+.mark-editor-single-view {
+    .mark-view-container {
+        background: white;
+    }
+}
+.chart-editor-canvas-view {
+    background: white;
+    flex: 1;
+    overflow: hidden;
+}
+
+.chart-editor-view {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+}
 .chart-editor-view {
     position: relative;
     .solving-hint {

--- a/sass/components/minimizable_panel.scss
+++ b/sass/components/minimizable_panel.scss
@@ -12,8 +12,25 @@
         flex-direction: column;
 
         & > .header {
+            .buttons {
+                float: right;
+                vertical-align: top;
+                padding-right: 2px;
+                height: $header-height;
+                line-height: $header-height;
+
+                .charticulator__button-flat {
+                    .svg-image-icon {
+                        padding: 2px;
+                        margin: 3px;
+                    }
+                }
+            }
+
             background-color: $gray-220;
+
             @include shadow-ambient;
+
             // border-top: 1px solid $gray-160;
             // border-bottom: 1px solid $gray-160;
             color: $gray-100;
@@ -26,7 +43,7 @@
             .svg-image-icon {
                 display: inline-block;
                 vertical-align: top;
-                margin: ($header-height - 14px) / 2 4px;
+                margin: (($header-height - 14px) / 2) 4px;
                 width: 14px;
                 height: 14px;
                 filter: invert(30%);
@@ -34,27 +51,113 @@
 
             &:hover {
                 background-color: $gray-230;
+
                 @include shadow-focused;
             }
 
             transition: background-color $transition-default, box-shadow $transition-default;
         }
+
         & > .content {
             flex-shrink: 0;
             padding: 10px;
         }
+
         &.minimizable-pane-scrollable {
             & > .content {
                 overflow-y: scroll;
             }
         }
+
         &.minimizable-pane-autosize {
             flex: 1;
             overflow: hidden;
+
             & > .content {
                 flex: 1;
                 overflow-y: scroll;
             }
         }
+    }
+}
+
+.charticulator__floating-panel {
+    z-index: 10;
+    border: 1px solid $gray-100;
+    border-radius: 2px;
+    box-sizing: border-box;
+    background: $gray-210;
+    position: absolute;
+    width: 322px;
+    left: 100px;
+    top: 100px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
+    @include shadow-ambient;
+
+    &-content {
+        flex: 1 1;
+        padding: 10px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+    }
+
+    &.is-scroll {
+        .charticulator__floating-panel-content {
+            overflow-x: hidden;
+            overflow-y: scroll;
+        }
+    }
+
+    &-header {
+        flex-shrink: 0;
+
+        .title {
+            pointer-events: none;
+            margin-left: 4px;
+        }
+
+        $header-height: 28px;
+
+        background-color: $gray-220;
+
+        @include shadow-ambient;
+
+        // border-top: 1px solid $gray-160;
+        // border-bottom: 1px solid $gray-160;
+        color: $gray-100;
+        height: $header-height;
+        line-height: $header-height;
+        font-size: 14px;
+        padding-left: 5px;
+        cursor: move;
+
+        .buttons {
+            float: right;
+            vertical-align: top;
+            padding-right: 2px;
+            height: $header-height;
+            line-height: $header-height;
+        }
+    }
+
+    &-resizer {
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        width: 10px;
+        height: 10px;
+        background: transparent;
+        pointer-events: all;
+        cursor: nwse-resize;
+    }
+
+    &.is-focus {
+        z-index: 11;
+
+        @include shadow-focused;
     }
 }

--- a/src/app/components/minimizable_panel.tsx
+++ b/src/app/components/minimizable_panel.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import { getSVGIcon } from "../resources";
 import { SVGImageIcon } from "./icons";
+import { ButtonFlatPanel, ButtonFlat } from "./buttons";
+import * as Hammer from "hammerjs";
+import { classNames } from "../utils";
 
 export class MinimizablePanelView extends React.Component<{}, {}> {
   public render() {
@@ -15,6 +18,7 @@ export interface MinimizablePaneProps {
   maxHeight?: number;
   hideHeader?: boolean;
   defaultMinimized?: boolean;
+  onMaximize?: () => void;
 }
 
 export interface MinimizablePaneState {
@@ -46,6 +50,15 @@ export class MinimizablePane extends React.Component<
           )}
         />
         <span className="title">{this.props.title}</span>
+        {this.props.onMaximize ? (
+          <span className="buttons" onClick={e => e.stopPropagation()}>
+            <ButtonFlat
+              title="Show as separate window"
+              url={getSVGIcon("general/popout")}
+              onClick={() => this.props.onMaximize()}
+            />
+          </span>
+        ) : null}
       </div>
     );
   }
@@ -97,5 +110,189 @@ export class MinimizablePane extends React.Component<
         );
       }
     }
+  }
+}
+
+export interface FloatingPanelProps {
+  title: string;
+  onClose?: () => void;
+  width?: number;
+  height?: number;
+  peerGroup: string;
+  scroll?: boolean;
+}
+export interface FloatingPanelState {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  focus: boolean;
+  minimized: boolean;
+}
+export class FloatingPanel extends React.Component<
+  FloatingPanelProps,
+  FloatingPanelState
+> {
+  protected refContainer: HTMLDivElement;
+  protected refHeader: HTMLElement;
+  protected refResizer: HTMLElement;
+
+  public state: FloatingPanelState = this.getInitialState();
+
+  public getInitialState(): FloatingPanelState {
+    // Figure out a position that doesn't overlap with existing windows
+    let initialX = 100;
+    let initialY = 100;
+    while (true) {
+      let found = false;
+      if (FloatingPanel.peerGroups.has(this.props.peerGroup)) {
+        for (const peer of FloatingPanel.peerGroups.get(this.props.peerGroup)) {
+          if (peer.state.x == initialX && peer.state.y == initialY) {
+            found = true;
+            break;
+          }
+        }
+      }
+      if (found && initialX < 400 && initialY < 400) {
+        initialX += 50;
+        initialY += 50;
+      } else {
+        break;
+      }
+    }
+    return {
+      x: initialX,
+      y: initialY,
+      width: 324,
+      height: 400,
+      focus: false,
+      minimized: false
+    };
+  }
+
+  protected hammer: HammerManager;
+
+  protected static peerGroups = new Map<string, Set<FloatingPanel>>();
+
+  public componentDidMount() {
+    this.hammer = new Hammer.Manager(this.refContainer);
+    this.hammer.add(new Hammer.Pan({ threshold: 0 }));
+    this.hammer.on("panstart", e => {
+      if (e.target == this.refHeader) {
+        const x0 = this.state.x - e.deltaX;
+        const y0 = this.state.y - e.deltaY;
+        const panListener: HammerListener = e => {
+          this.setState({
+            x: x0 + e.deltaX,
+            y: Math.max(0, y0 + e.deltaY)
+          });
+        };
+        const panEndListener = () => {
+          this.hammer.off("pan", panListener);
+          this.hammer.off("panend", panEndListener);
+        };
+        this.hammer.on("pan", panListener);
+        this.hammer.on("panend", panEndListener);
+      }
+      if (e.target == this.refResizer) {
+        const x0 = this.state.width - e.deltaX;
+        const y0 = this.state.height - e.deltaY;
+        const panListener: HammerListener = e => {
+          this.setState({
+            width: Math.max(324, x0 + e.deltaX),
+            height: Math.max(100, y0 + e.deltaY)
+          });
+        };
+        const panEndListener = () => {
+          this.hammer.off("pan", panListener);
+          this.hammer.off("panend", panEndListener);
+        };
+        this.hammer.on("pan", panListener);
+        this.hammer.on("panend", panEndListener);
+      }
+    });
+
+    if (FloatingPanel.peerGroups.has(this.props.peerGroup)) {
+      FloatingPanel.peerGroups.get(this.props.peerGroup).add(this);
+    } else {
+      FloatingPanel.peerGroups.set(this.props.peerGroup, new Set([this]));
+    }
+
+    this.focus();
+  }
+
+  public focus() {
+    if (FloatingPanel.peerGroups.has(this.props.peerGroup)) {
+      for (const peer of FloatingPanel.peerGroups.get(this.props.peerGroup)) {
+        if (peer != this) {
+          peer.setState({ focus: false });
+        }
+      }
+    }
+    this.setState({ focus: true });
+  }
+
+  public componentWillUnmount() {
+    this.hammer.destroy();
+    if (FloatingPanel.peerGroups.has(this.props.peerGroup)) {
+      FloatingPanel.peerGroups.get(this.props.peerGroup).delete(this);
+    }
+  }
+
+  public render() {
+    return (
+      <div
+        className={classNames(
+          "charticulator__floating-panel",
+          ["is-focus", this.state.focus],
+          ["is-scroll", this.props.scroll]
+        )}
+        ref={e => (this.refContainer = e)}
+        style={{
+          left: this.state.x + "px",
+          top: this.state.y + "px",
+          width: this.state.width + "px",
+          height: this.state.minimized ? undefined : this.state.height + "px"
+        }}
+        onMouseDown={e => {
+          this.focus();
+        }}
+        onTouchStart={e => {
+          this.focus();
+        }}
+      >
+        <div
+          className="charticulator__floating-panel-header"
+          ref={e => (this.refHeader = e)}
+        >
+          <span className="title">{this.props.title}</span>
+          <span className="buttons" onClick={e => e.stopPropagation()}>
+            <ButtonFlat
+              url={getSVGIcon("general/minus")}
+              title="Minimize"
+              onClick={() =>
+                this.setState({ minimized: !this.state.minimized })
+              }
+            />
+            <ButtonFlat
+              url={getSVGIcon("general/popout")}
+              title="Restore to panel"
+              onClick={() => this.props.onClose()}
+            />
+          </span>
+        </div>
+        {!this.state.minimized ? (
+          <div className="charticulator__floating-panel-content">
+            {this.props.children}
+          </div>
+        ) : null}
+        {!this.state.minimized ? (
+          <div
+            className="charticulator__floating-panel-resizer"
+            ref={e => (this.refResizer = e)}
+          />
+        ) : null}
+      </div>
+    );
   }
 }

--- a/src/app/main_view.tsx
+++ b/src/app/main_view.tsx
@@ -6,7 +6,8 @@ import {
   SVGImageIcon,
   AppButton,
   ToolButton,
-  ErrorBoundary
+  ErrorBoundary,
+  FloatingPanel
 } from "./components";
 import * as R from "./resources";
 
@@ -43,7 +44,11 @@ export interface MainViewProps {
   disableFileView?: boolean;
 }
 
-export interface MainViewState {}
+export interface MainViewState {
+  glyphViewMaximized: boolean;
+  layersViewMaximized: boolean;
+  attributeViewMaximized: boolean;
+}
 
 export class MainView extends React.Component<MainViewProps, MainViewState> {
   public refs: {
@@ -54,7 +59,11 @@ export class MainView extends React.Component<MainViewProps, MainViewState> {
   constructor(props: MainViewProps) {
     super(props);
 
-    this.state = {};
+    this.state = {
+      glyphViewMaximized: false,
+      layersViewMaximized: false,
+      attributeViewMaximized: false
+    };
 
     this.onKeyDown = this.onKeyDown.bind(this);
   }
@@ -339,23 +348,61 @@ export class MainView extends React.Component<MainViewProps, MainViewState> {
               <Toolbar store={this.props.store.chartStore} />
             </div>
             <div className="charticulator__panel-editor-panel-container">
-              <div className="charticulator__panel-editor-panel charticulator__panel-editor-panel-panes">
+              <div
+                className="charticulator__panel-editor-panel charticulator__panel-editor-panel-panes"
+                style={{
+                  display:
+                    this.state.glyphViewMaximized &&
+                    this.state.attributeViewMaximized &&
+                    this.state.layersViewMaximized
+                      ? "none"
+                      : undefined
+                }}
+              >
                 <MinimizablePanelView>
-                  <MinimizablePane title="Glyph" scroll={false}>
-                    <ErrorBoundary>
-                      <MarkEditorView store={this.props.store.chartStore} />
-                    </ErrorBoundary>
-                  </MinimizablePane>
-                  <MinimizablePane title="Layers" scroll={true} maxHeight={200}>
-                    <ErrorBoundary>
-                      <ObjectListEditor />
-                    </ErrorBoundary>
-                  </MinimizablePane>
-                  <MinimizablePane title="Attributes" scroll={true}>
-                    <ErrorBoundary>
-                      <AttributePanel store={this.props.store.chartStore} />
-                    </ErrorBoundary>
-                  </MinimizablePane>
+                  {this.state.glyphViewMaximized ? null : (
+                    <MinimizablePane
+                      title="Glyph"
+                      scroll={false}
+                      onMaximize={() =>
+                        this.setState({ glyphViewMaximized: true })
+                      }
+                    >
+                      <ErrorBoundary>
+                        <MarkEditorView
+                          store={this.props.store.chartStore}
+                          height={300}
+                        />
+                      </ErrorBoundary>
+                    </MinimizablePane>
+                  )}
+                  {this.state.layersViewMaximized ? null : (
+                    <MinimizablePane
+                      title="Layers"
+                      scroll={true}
+                      maxHeight={200}
+                      onMaximize={() =>
+                        this.setState({ layersViewMaximized: true })
+                      }
+                    >
+                      <ErrorBoundary>
+                        <ObjectListEditor />
+                      </ErrorBoundary>
+                    </MinimizablePane>
+                  )}
+                  {this.state.attributeViewMaximized ? null : (
+                    <MinimizablePane
+                      title="Attributes"
+                      scroll={true}
+                      onMaximize={() =>
+                        this.setState({ attributeViewMaximized: true })
+                      }
+                    >
+                      <ErrorBoundary>
+                        <AttributePanel store={this.props.store.chartStore} />
+                      </ErrorBoundary>
+                    </MinimizablePane>
+                  )}
                 </MinimizablePanelView>
               </div>
               <div className="charticulator__panel-editor-panel charticulator__panel-editor-panel-chart">
@@ -366,6 +413,43 @@ export class MainView extends React.Component<MainViewProps, MainViewState> {
             </div>
           </div>
         </section>
+        <div className="charticulator__floating-panels">
+          {this.state.glyphViewMaximized ? (
+            <FloatingPanel
+              peerGroup="panels"
+              title="Glyph"
+              onClose={() => this.setState({ glyphViewMaximized: false })}
+            >
+              <ErrorBoundary>
+                <MarkEditorView store={this.props.store.chartStore} />
+              </ErrorBoundary>
+            </FloatingPanel>
+          ) : null}
+          {this.state.layersViewMaximized ? (
+            <FloatingPanel
+              scroll={true}
+              peerGroup="panels"
+              title="Layers"
+              onClose={() => this.setState({ layersViewMaximized: false })}
+            >
+              <ErrorBoundary>
+                <ObjectListEditor />
+              </ErrorBoundary>
+            </FloatingPanel>
+          ) : null}
+          {this.state.attributeViewMaximized ? (
+            <FloatingPanel
+              scroll={true}
+              peerGroup="panels"
+              title="Attributes"
+              onClose={() => this.setState({ attributeViewMaximized: false })}
+            >
+              <ErrorBoundary>
+                <AttributePanel store={this.props.store.chartStore} />
+              </ErrorBoundary>
+            </FloatingPanel>
+          ) : null}
+        </div>
         <PopupContainer controller={globals.popupController} />
         <DragStateView controller={globals.dragController} />
       </div>

--- a/src/app/resources/icons.ts
+++ b/src/app/resources/icons.ts
@@ -81,7 +81,7 @@ addSVGIcon(
 );
 
 addSVGIcon(
-  "general/copy",
+  "general/popout",
   require("url-loader!resources/icons/icons_popout.svg")
 );
 


### PR DESCRIPTION
Resolves #21

- Floating panels: glyph, attribute, and layers panels
- Make glyph editor resizable when popped out (useful for long/wide glyphs)