### PR TITLE
Better migration and fix text mapping issue

### DIFF
--- a/src/about.ts
+++ b/src/about.ts
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT license.
+*/
 fetch("data/THIRD_PARTY.json")
   .then(res => res.json())
   .then(

--- a/src/app/stores/migrator.ts
+++ b/src/app/stores/migrator.ts
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT license.
+*/
 import { MainStoreState } from "./main_store";
 import {
   compareVersion,

--- a/src/app/stores/migrator.ts
+++ b/src/app/stores/migrator.ts
@@ -1,5 +1,11 @@
 import { MainStoreState } from "./main_store";
-import { compareVersion, zip, Prototypes, Specification } from "../../core";
+import {
+  compareVersion,
+  zip,
+  Prototypes,
+  Specification,
+  Expression
+} from "../../core";
 
 /** Upgrade old versions of chart spec and state to newer version */
 export class Migrator {
@@ -19,7 +25,6 @@ export class Migrator {
       // Major change in spec from 1.1.0: the dataRowIndices are changed from number[] to number[][]
       state = this.fixDataRowIndices(state);
       state = this.fixDataMappingExpressions(state);
-      // TODO: also need to fix orderBy expressions
     }
 
     return state;
@@ -41,7 +46,80 @@ export class Migrator {
     return state;
   }
 
+  public addAggregationToExpression(expr: string, valueType: string) {
+    if (valueType == "number") {
+      return "avg(" + expr + ")";
+    } else {
+      return "first(" + expr + ")";
+    }
+  }
+
+  public fixAxisDataMapping(
+    mapping: Specification.Types.AxisDataBinding,
+    table: string
+  ) {
+    if (!mapping) {
+      return;
+    }
+    mapping.expression = this.addAggregationToExpression(
+      mapping.expression,
+      mapping.valueType
+    );
+  }
+
   public fixDataMappingExpressions(state: MainStoreState) {
+    for (const [element, elementState] of zip(
+      state.chart.chart.elements,
+      state.chart.chartState.elements
+    )) {
+      if (Prototypes.isType(element.classID, "plot-segment")) {
+        const plotSegment = element as Specification.PlotSegment;
+        this.fixAxisDataMapping(
+          plotSegment.properties.xData as any,
+          plotSegment.table
+        );
+        this.fixAxisDataMapping(
+          plotSegment.properties.yData as any,
+          plotSegment.table
+        );
+        if (plotSegment.properties.sublayout) {
+          const sublayout = plotSegment.properties.sublayout as any;
+          if (sublayout.order) {
+            const parsed = Expression.parse(sublayout.order);
+            let expr = null;
+            // This is supposed to be in the form of sortBy((x) => x.Column);
+            if (parsed instanceof Expression.FunctionCall) {
+              if (parsed.name == "sortBy") {
+                if (parsed.args[0] instanceof Expression.LambdaFunction) {
+                  const lambda = parsed.args[0] as Expression.LambdaFunction;
+                  if (lambda.expr instanceof Expression.FieldAccess) {
+                    const field = lambda.expr as Expression.FieldAccess;
+                    const column = field.fields[0];
+                    expr = Expression.functionCall(
+                      "first",
+                      Expression.variable(column)
+                    ).toString();
+                  }
+                }
+              }
+            }
+            if (expr) {
+              sublayout.order = { expression: expr };
+            }
+          }
+        }
+        if (plotSegment.filter) {
+          if ((plotSegment.filter.categories as any).column) {
+            const column = (plotSegment.filter.categories as any).column;
+            delete (plotSegment.filter.categories as any).column;
+            plotSegment.filter.categories.expression = Expression.variable(
+              column
+            ).toString();
+          }
+        }
+      }
+    }
+    // Fix data mapping on glyphs/marks
     for (const glyph of state.chart.chart.glyphs) {
       for (const mark of glyph.marks) {
         for (const key in mark.mappings) {
@@ -49,19 +127,37 @@ export class Migrator {
             const mapping = mark.mappings[key];
             if (mapping.type == "scale") {
               const scaleMapping = mapping as Specification.ScaleMapping;
-              if (scaleMapping.valueType == "number") {
-                scaleMapping.expression =
-                  "avg(" + scaleMapping.expression + ")";
-              } else {
-                scaleMapping.expression =
-                  "first(" + scaleMapping.expression + ")";
-              }
+              scaleMapping.expression = this.addAggregationToExpression(
+                scaleMapping.expression,
+                scaleMapping.valueType
+              );
+            }
+            if (mapping.type == "scale" || mapping.type == "text") {
+              (mapping as any).table = glyph.table;
             }
           }
         }
       }
-      return state;
     }
-    // TODO: fix plot segment axis data mappings as well
+    // Fix axis data mappings for data-axes
+    for (const glyph of state.chart.chart.glyphs) {
+      for (const mark of glyph.marks) {
+        if (Prototypes.isType(mark.classID, "mark.data-axis")) {
+          const properties = mark.properties as any;
+          console.log(properties);
+          const valueType: string = properties.axis.valueType;
+          properties.axis.expression = this.addAggregationToExpression(
+            properties.axis.expression,
+            valueType
+          );
+          if (properties.dataExpressions) {
+            properties.dataExpressions = properties.dataExpressions.map(
+              (x: string) => this.addAggregationToExpression(x, valueType)
+            );
+          }
+        }
+      }
+    }
+    return state;
   }
 }

--- a/src/app/views/dataset/common.ts
+++ b/src/app/views/dataset/common.ts
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT license.
+*/
 import { Dataset } from "../../../core";
 
 export const kind2Icon: { [name: string]: string } = {

--- a/src/app/views/panels/widgets/groupby_editor.tsx
+++ b/src/app/views/panels/widgets/groupby_editor.tsx
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT license.
+*/
 import * as React from "react";
 import { Expression, Prototypes, Specification } from "../../../../core";
 import { Actions } from "../../../actions";

--- a/src/core/prototypes/state.ts
+++ b/src/core/prototypes/state.ts
@@ -737,6 +737,9 @@ export class ChartStateManager {
 
   /** Get chart-level data context for a given table */
   public getChartDataContext(tableName: string): Expression.Context {
+    if (tableName == null) {
+      return null;
+    }
     const table = this.dataflow.getTable(tableName);
     return table.getGroupedContext(makeRange(0, table.rows.length));
   }

--- a/src/core/solver/solver.ts
+++ b/src/core/solver/solver.ts
@@ -71,8 +71,8 @@ export class BaseSolver {
     rowContext: Expression.Context
   ) {
     if (
-      (rowContext == null && mapping.type == "scale") ||
-      mapping.type == "text"
+      rowContext == null &&
+      (mapping.type == "scale" || mapping.type == "text")
     ) {
       const xMapping =
         (mapping as Specification.ScaleMapping) ||

--- a/src/worker/communication.ts
+++ b/src/worker/communication.ts
@@ -92,7 +92,7 @@ export class WorkerHostProcess {
                       {
                         type: "rpc-error",
                         instanceID: message.instanceID,
-                        errorMessage: error.message
+                        errorMessage: error.message + "\n" + error.stack
                       },
                       undefined
                     );
@@ -113,7 +113,7 @@ export class WorkerHostProcess {
               {
                 type: "rpc-error",
                 instanceID: message.instanceID,
-                errorMessage: e.message
+                errorMessage: e.message + "\n" + e.stack
               },
               undefined
             );


### PR DESCRIPTION
Update the migration script to convert 1.0.0 chart states to 1.1.0. Also fixed a text mapping issue that causes mingrated/fresh charts to display the same thing on data-mapped texts.