### PR TITLE
Update multirun and polish build.js

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,107 +2,131 @@ const fs = require("fs-extra");
 const jsyaml = require("js-yaml");
 const multirun = require("multirun");
 
+/** Convert a YAML file to JSON */
 function yamlToJSON(yamlFile, jsonFile) {
-    return fs.readFile(yamlFile).then((contents) => {
-        let doc = jsyaml.safeLoad(contents);
-        let json = JSON.stringify(doc);
-        return fs.writeFile(jsonFile, new Buffer(json, "utf-8"));
-    });
+  return fs.readFile(yamlFile).then((contents) => {
+    let doc = jsyaml.safeLoad(contents);
+    let json = JSON.stringify(doc);
+    return fs.writeFile(jsonFile, Buffer.from(json, "utf-8"));
+  });
 }
 
-function yamlToJavaScript(yamlFile, javascriptFile, variableName, addlConfig = {}) {
-    return fs.readFile(yamlFile).then((contents) => {
-        let doc = {
-            ...(jsyaml.safeLoad(contents)),
-            ...addlConfig
-        };
-        let json = JSON.stringify(doc);
-        let javascript = `var ${variableName} = ${json};\n`;
-        return fs.writeFile(javascriptFile, new Buffer(javascript, "utf-8"));
-    });
-}
-
-function copyFolder(folder1, folder2) {
-    if (fs.existsSync(folder1)) {
-        fs.copy(folder1, folder2);
+/** Convert a YAML file to JavaScript variable */
+function yamlToJavaScript(yamlFile, javascriptFile, variableName, mixin) {
+  return fs.readFile(yamlFile).then((contents) => {
+    let doc = jsyaml.safeLoad(contents);
+    if (mixin != undefined) {
+      mixin(doc);
     }
+    let json = JSON.stringify(doc);
+    let javascript = `var ${variableName} = ${json};\n`;
+    return fs.writeFile(javascriptFile, Buffer.from(javascript, "utf-8"));
+  });
 }
 
-const isProd = process.env.NODE_ENV === 'production';
+/** Copy folder1 to folder2 */
+function copyFolder(folder1, folder2) {
+  if (fs.existsSync(folder1)) {
+    fs.copy(folder1, folder2);
+  }
+}
+
+// Parse environment variable
+const isProd = process.env.NODE_ENV === "production";
+
+// The default dev sequence
+const devSequence = ["cleanup", "makedirs", "copy", "third_party_data", "config", "pegjs", "typescript", "sass", "webpack"];
 
 let COMMANDS = {
 
-    // Remove the entire build directory
-    cleanup: () => fs.remove("dist"),
+  // Remove the entire build directory
+  cleanup: () => fs.remove("dist"),
 
-    // Create necessary directories
-    makedirs: [
-        () => fs.mkdirs("dist/styles"),
-        () => fs.mkdirs("dist/data"),
-        () => fs.mkdirs("dist/scripts/core/expression")
-    ],
+  // Create necessary directories
+  makedirs: [
+    () => fs.mkdirs("dist/styles"),
+    () => fs.mkdirs("dist/data"),
+    () => fs.mkdirs("dist/scripts/core/expression")
+  ],
 
-    // Copy files
-    copy: [
-        () => fs.copy("src/core/expression/parser.d.ts", "dist/scripts/core/expression/parser.d.ts"),
+  // Copy files
+  copy: [
+    () => fs.copy("src/core/expression/parser.d.ts", "dist/scripts/core/expression/parser.d.ts"),
 
-        // Copy all of the public files
-        () => copyFolder("./public", "./dist"),
+    // Copy all of the public files
+    () => copyFolder("./public", "./dist"),
 
-        // Copy all of the extensions
-        () => copyFolder("./extensions", "./dist/extensions"),
+    // Copy all of the extensions
+    () => copyFolder("./extensions", "./dist/extensions"),
 
-        // Copy all of the datasets
-        () => copyFolder("./datasets", "./dist/datasets"),
-    ],
+    // Copy all of the datasets
+    () => copyFolder("./datasets", "./dist/datasets"),
+  ],
 
-    // Convert the THIRD_PARTY.yml to json
-    third_party_data: () => yamlToJSON("THIRD_PARTY.yml", "dist/data/THIRD_PARTY.json"),
+  // Convert the THIRD_PARTY.yml to json
+  third_party_data: () => yamlToJSON("THIRD_PARTY.yml", "dist/data/THIRD_PARTY.json"),
 
-    // Convert the config.yml to config.js
-    config: () => {
-        let mixin = {};
-        if (fs.existsSync('datasets/files.json')) {
-            mixin.SampleDatasets = JSON.parse(fs.readFileSync('datasets/files.json'));
-            mixin.SampleDatasets.forEach(dataset => {
-                dataset.tables.forEach(table => {
-                    table.url = 'datasets/' + table.url;
-                });
-            });
+  // Convert the config.yml to config.js
+  config: async () => {
+    let mixin = (doc) => {
+      if (fs.existsSync("datasets/files.json")) {
+        let sampleDatasets = JSON.parse(fs.readFileSync("datasets/files.json"));
+        sampleDatasets.forEach(dataset => {
+          dataset.tables.forEach(table => {
+            table.url = "datasets/" + table.url;
+          });
+        });
+        if (doc.SampleDatasets) {
+          doc.SampleDatasets = doc.SampleDatasets.concat(sampleDatasets);
+        } else {
+          doc.SampleDatasets = sampleDatasets;
         }
-        yamlToJavaScript("config.yml", "dist/data/config.js", "CHARTICULATOR_CONFIG", mixin)
-    },
+      }
+    }
+    await yamlToJavaScript("config.yml", "dist/data/config.js", "CHARTICULATOR_CONFIG", mixin);
+  },
 
-    // Compile sass files
-    sass: [
-        "node-sass sass/app.scss -o dist/styles",
-        "node-sass sass/page.scss -o dist/styles"
-    ],
+  // Compile sass files
+  sass: {
+    app: "node-sass sass/app.scss -o dist/styles",
+    page: "node-sass sass/page.scss -o dist/styles"
+  },
 
-    // Compile the PEGJS parser
-    pegjs: [
-        "pegjs --format commonjs --allowed-start-rules start,start_text -o dist/scripts/core/expression/parser.js src/core/expression/parser.pegjs",
-    ],
+  // Compile the PEGJS parser
+  pegjs: "pegjs --format commonjs --allowed-start-rules start,start_text -o dist/scripts/core/expression/parser.js src/core/expression/parser.pegjs",
 
-    // Compile TypeScript
-    typescript: "tsc",
+  // Compile TypeScript
+  typescript: "tsc",
 
-    // Produce webpack bundles
-    webpack: "webpack --mode=" + (isProd ? "production" : "development"),
+  // Produce webpack bundles
+  webpack: "webpack --mode=" + (isProd ? "production" : "development"),
 
-    server: "http-server ./dist -a 127.0.0.1 -p 4000 -c-1 -s",
-    public_server: "http-server ./dist -a 0.0.0.0 -p 4000 -c-1 -s",
-    watch: [
-        "tsc -w",
-        "webpack -w --mode=" + (isProd ? "production" : "development"),
-        "node-sass --watch sass/app.scss sass/page.scss -o dist/styles",
-        () => multirun.run(COMMANDS["server"])
-    ]
+  server: "http-server ./dist -a 127.0.0.1 -p 4000 -c-1 -s",
+  public_server: "http-server ./dist -a 0.0.0.0 -p 4000 -c-1 -s",
+  watch: {
+    tsc: "tsc -w",
+    webpack: "webpack -w --mode=" + (isProd ? "production" : "development"),
+    sass: "node-sass --watch sass/app.scss sass/page.scss -o dist/styles",
+    server: "http-server ./dist -a 127.0.0.1 -p 4000 -c-1 -s"
+  },
+
+  dev: () => runCommands(devSequence)
 };
+
+/** Run the specified commands names in sequence */
+async function runCommands(sequence) {
+  for (const cmd of sequence) {
+    console.log("Build: " + cmd);
+    await multirun.run(COMMANDS[cmd]);
+  }
+}
 
 // Execute the specified commands, with no args, run the default sequence
 let sequence = process.argv.slice(2);
 if (sequence.length == 0) {
-    sequence = ["cleanup", "makedirs", "copy", "third_party_data", "config", "pegjs", "typescript", "sass", "webpack"];
+  sequence = devSequence;
 }
-multirun.runCommands(COMMANDS, sequence, "Build");
+runCommands(sequence).catch((e) => {
+  console.log(e.message);
+  process.exit(-1);
+});

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "server": "node build.js server",
     "public_server": "node build.js public_server",
     "watch": "node build.js watch",
-    "start": "run-s dev watch",
+    "start": "node build.js dev watch",
     "lint": "tslint 'src/**/*.{ts,tsx}'",
     "prettify": "prettier 'src/**/*.{ts,tsx}'",
     "unit_test": "NODE_PATH=. mocha dist/scripts/tests",
-    "test": "run-s lint dev unit_test",
+    "test": "yarn run lint && yarn run dev && yarn run unit_test",
     "add_licenses": "license-check-and-add"
   },
   "lint-staged": {
@@ -44,13 +44,19 @@
     "react-dom": "16.3.2"
   },
   "license-check-and-add-config": {
-      "folder": ".",
-      "license": "header.txt",
-      "exact_paths_method": "INCLUDE",
-      "exact_paths": ["src"],
-      "file_type_method": "INCLUDE",
-      "file_types": [".js", ".tsx", ".ts"],
-      "insert_license": true
+    "folder": ".",
+    "license": "header.txt",
+    "exact_paths_method": "INCLUDE",
+    "exact_paths": [
+      "src"
+    ],
+    "file_type_method": "INCLUDE",
+    "file_types": [
+      ".js",
+      ".tsx",
+      ".ts"
+    ],
+    "insert_license": true
   },
   "devDependencies": {
     "@types/chai": "4.0.1",
@@ -71,9 +77,8 @@
     "license-check-and-add": "^2.3.6",
     "lint-staged": "^7.1.0",
     "mocha": "5.0.5",
-    "multirun": "2.0.0",
+    "multirun": "^3.0.1",
     "node-sass": "^4.9.0",
-    "npm-run-all": "^4.1.3",
     "pegjs": "0.10.0",
     "preact": "^8.3.1",
     "preact-compat": "^3.18.3",

--- a/src/about.ts
+++ b/src/about.ts
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT license.
+*/
 fetch("data/THIRD_PARTY.json")
   .then(res => res.json())
   .then(

--- a/src/app/stores/migrator.ts
+++ b/src/app/stores/migrator.ts
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT license.
+*/
 import { MainStoreState } from "./main_store";
 import { compareVersion, zip, Prototypes, Specification } from "../../core";
 

--- a/src/app/views/dataset/common.ts
+++ b/src/app/views/dataset/common.ts
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT license.
+*/
 import { Dataset } from "../../../core";
 
 export const kind2Icon: { [name: string]: string } = {

--- a/src/app/views/panels/widgets/groupby_editor.tsx
+++ b/src/app/views/panels/widgets/groupby_editor.tsx
@@ -1,3 +1,7 @@
+/*
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT license.
+*/
 import * as React from "react";
 import { Expression, Prototypes, Specification } from "../../../../core";
 import { Actions } from "../../../actions";

--- a/yarn.lock
+++ b/yarn.lock
@@ -503,21 +503,9 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
-array-filter@~0.0.0:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
-
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
-
-array-map@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
-
-array-reduce@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -883,7 +871,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -1033,7 +1021,7 @@ commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
-commander@^2.12.1, commander@^2.14.1, commander@^2.9.0:
+commander@2.15.1, commander@^2.12.1, commander@^2.14.1, commander@^2.9.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
@@ -1162,7 +1150,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.4, cross-spawn@^6.0.5:
+cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   dependencies:
@@ -1331,13 +1319,6 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-define-properties@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
-  dependencies:
-    foreach "^2.0.5"
-    object-keys "^1.0.8"
-
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -1397,10 +1378,6 @@ domexception@^1.0.0:
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
   dependencies:
     webidl-conversions "^4.0.2"
-
-duplexer@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.6.0"
@@ -1478,24 +1455,6 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.4.3:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
-  dependencies:
-    es-to-primitive "^1.1.1"
-    function-bind "^1.1.1"
-    has "^1.0.1"
-    is-callable "^1.1.3"
-    is-regex "^1.0.4"
-
-es-to-primitive@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
-  dependencies:
-    is-callable "^1.1.1"
-    is-date-object "^1.0.1"
-    is-symbol "^1.0.1"
-
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -1539,18 +1498,6 @@ estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
-
-event-stream@~3.3.0:
-  version "3.3.4"
-  resolved "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
-  dependencies:
-    duplexer "~0.1.1"
-    from "~0"
-    map-stream "~0.1.0"
-    pause-stream "0.0.11"
-    split "0.3"
-    stream-combiner "~0.0.4"
-    through "~2.3.1"
 
 eventemitter3@^3.0.0:
   version "3.1.0"
@@ -1805,10 +1752,6 @@ for-own@^0.1.4:
   dependencies:
     for-in "^1.0.1"
 
-foreach@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
-
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -1841,10 +1784,6 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
-
-from@~0:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
 
 fs-access@^1.0.0:
   version "1.0.1"
@@ -1894,10 +1833,6 @@ fstream@^1.0.0, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
-
-function-bind@^1.0.2, function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -2019,6 +1954,10 @@ growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
 
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+
 hammerjs@2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
@@ -2087,12 +2026,6 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
-
-has@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
-  dependencies:
-    function-bind "^1.0.2"
 
 hash-base@^3.0.0:
   version "3.0.4"
@@ -2351,10 +2284,6 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.1.1, is-callable@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
-
 is-ci@^1.0.10:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
@@ -2372,10 +2301,6 @@ is-data-descriptor@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
   dependencies:
     kind-of "^6.0.0"
-
-is-date-object@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -2531,12 +2456,6 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
-is-regex@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
-  dependencies:
-    has "^1.0.1"
-
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
@@ -2544,10 +2463,6 @@ is-regexp@^1.0.0:
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-
-is-symbol@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -2792,10 +2707,6 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-
 jsonpointer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
@@ -2953,15 +2864,6 @@ load-json-file@^1.0.0, load-json-file@^1.1.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-load-json-file@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^4.0.0"
-    pify "^3.0.0"
-    strip-bom "^3.0.0"
-
 loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
@@ -3066,10 +2968,6 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-map-stream@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
-
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
@@ -3099,10 +2997,6 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
-
-memorystream@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
 
 meow@^3.7.0:
   version "3.7.0"
@@ -3192,7 +3086,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -3266,6 +3160,22 @@ mocha@5.0.5:
     mkdirp "0.5.1"
     supports-color "4.4.0"
 
+mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+  dependencies:
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.2"
+    growl "1.10.5"
+    he "1.1.1"
+    minimatch "3.0.4"
+    mkdirp "0.5.1"
+    supports-color "5.4.0"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -3281,9 +3191,11 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-multirun@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/multirun/-/multirun-2.0.0.tgz#27a440ce551ac6bf37565386a7b297010f297abe"
+multirun@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/multirun/-/multirun-3.0.1.tgz#26568131c7e737469856ec400447d3534a5d5f9b"
+  dependencies:
+    mocha "^5.2.0"
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -3471,20 +3383,6 @@ npm-path@^2.0.2:
   dependencies:
     which "^1.2.10"
 
-npm-run-all@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.3.tgz#49f15b55a66bb4101664ce270cb18e7103f8f185"
-  dependencies:
-    ansi-styles "^3.2.0"
-    chalk "^2.1.0"
-    cross-spawn "^6.0.4"
-    memorystream "^0.3.1"
-    minimatch "^3.0.4"
-    ps-tree "^1.1.0"
-    read-pkg "^3.0.0"
-    shell-quote "^1.6.1"
-    string.prototype.padend "^3.0.0"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -3535,10 +3433,6 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
-
-object-keys@^1.0.8:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -3757,21 +3651,9 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-path-type@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
-  dependencies:
-    pify "^3.0.0"
-
 pathval@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
-
-pause-stream@0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
-  dependencies:
-    through "~2.3"
 
 pbkdf2@^3.0.3:
   version "3.0.16"
@@ -3931,12 +3813,6 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
 
-ps-tree@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
-  dependencies:
-    event-stream "~3.3.0"
-
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -4060,14 +3936,6 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
-
-read-pkg@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
-  dependencies:
-    load-json-file "^4.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^3.0.0"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
   version "2.3.6"
@@ -4397,15 +4265,6 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shell-quote@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
-  dependencies:
-    array-filter "~0.0.0"
-    array-map "~0.0.0"
-    array-reduce "~0.0.0"
-    jsonify "~0.0.0"
-
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -4524,12 +4383,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-split@0.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
-  dependencies:
-    through "2"
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -4590,12 +4443,6 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-combiner@~0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
-  dependencies:
-    duplexer "~0.1.1"
-
 stream-each@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.2.tgz#8e8c463f91da8991778765873fe4d960d8f616bd"
@@ -4642,14 +4489,6 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string.prototype.padend@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz#f3aaef7c1719f170c5eab1c32bf780d96e21f2f0"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.4.3"
-    function-bind "^1.0.2"
-
 string_decoder@^1.0.0, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -4686,10 +4525,6 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -4714,15 +4549,15 @@ supports-color@4.4.0:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-
-supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@5.4.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
 symbol-observable@1.0.1:
   version "1.0.1"
@@ -4771,7 +4606,7 @@ through2@^2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@2, through@^2.3.6, through@~2.3, through@~2.3.1:
+through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
Upgrade the multirun package to 3.0.1, and polish the build.js script. The main reason is `yarn start` won't fail if the initial `tsc` command is unsuccessful. This will cause the sass files to not build, and thus produce a unusable version. The new multirun package can now correctly emit errors. Also fixed several node warnings regarding the deprecated Buffer constructor. @stopyoukid please test the changes in Windows.