### PR TITLE
Import template for nested chart

### DIFF
--- a/src/app/components/color_picker.tsx
+++ b/src/app/components/color_picker.tsx
@@ -441,7 +441,9 @@ export class GradientView extends React.PureComponent<
       this.props.gradient.colors,
       this.props.gradient.colorspace
     );
-    setImmediate(() => {
+    // Somehow Chrome doesn't like get/putImageData here,
+    // it prevents any popout view containing it from showing
+    setTimeout(() => {
       const data = ctx.getImageData(0, 0, width, height);
       for (let i = 0; i < data.width; i++) {
         const t = i / (data.width - 1);
@@ -455,7 +457,7 @@ export class GradientView extends React.PureComponent<
         }
       }
       ctx.putImageData(data, 0, 0);
-    });
+    }, 0);
   }
 
   public render() {

--- a/src/app/components/color_picker.tsx
+++ b/src/app/components/color_picker.tsx
@@ -441,19 +441,21 @@ export class GradientView extends React.PureComponent<
       this.props.gradient.colors,
       this.props.gradient.colorspace
     );
-    const data = ctx.getImageData(0, 0, width, height);
-    for (let i = 0; i < data.width; i++) {
-      const t = i / (data.width - 1);
-      const c = scale(t);
-      for (let y = 0; y < data.height; y++) {
-        let ptr = (i + y * data.width) * 4;
-        data.data[ptr++] = c.r;
-        data.data[ptr++] = c.g;
-        data.data[ptr++] = c.b;
-        data.data[ptr++] = 255;
+    setImmediate(() => {
+      const data = ctx.getImageData(0, 0, width, height);
+      for (let i = 0; i < data.width; i++) {
+        const t = i / (data.width - 1);
+        const c = scale(t);
+        for (let y = 0; y < data.height; y++) {
+          let ptr = (i + y * data.width) * 4;
+          data.data[ptr++] = c.r;
+          data.data[ptr++] = c.g;
+          data.data[ptr++] = c.b;
+          data.data[ptr++] = 255;
+        }
       }
-    }
-    ctx.putImageData(data, 0, 0);
+      ctx.putImageData(data, 0, 0);
+    });
   }
 
   public render() {

--- a/src/app/stores/main_store.ts
+++ b/src/app/stores/main_store.ts
@@ -107,24 +107,28 @@ export class MainStore extends BaseStore {
 
     this.chartStore = new ChartStore(this);
 
-    if (process.env.NODE_ENV === "development") {
-      // Only enable this if we are in the development environment
-      this.registerExportTemplateTarget(
-        "Charticulator Template",
-        (template: Specification.Template.ChartTemplate) => {
-          return {
-            getProperties: () => [],
-            getFileExtension: () => "json",
-            generate: () => {
-              return new Promise<string>((resolve, reject) => {
-                const r = btoa(JSON.stringify(template, null, 2));
-                resolve(r);
-              });
+    this.registerExportTemplateTarget(
+      "Charticulator Template",
+      (template: Specification.Template.ChartTemplate) => {
+        return {
+          getProperties: () => [
+            {
+              displayName: "Name",
+              name: "name",
+              type: "string",
+              default: "template"
             }
-          };
-        }
-      );
-    }
+          ],
+          getFileName: (props: { name: string }) => `${props.name}.json`,
+          generate: () => {
+            return new Promise<string>((resolve, reject) => {
+              const r = btoa(JSON.stringify(template, null, 2));
+              resolve(r);
+            });
+          }
+        };
+      }
+    );
   }
 
   public saveState(): MainStoreState {

--- a/src/app/template/index.ts
+++ b/src/app/template/index.ts
@@ -21,8 +21,10 @@ export interface ExportTemplateTargetProperty {
 export interface ExportTemplateTarget {
   /** Get export format properties, such as template name, author */
   getProperties(): ExportTemplateTargetProperty[];
-  /** Get the file extension */
-  getFileExtension(): string;
+  /** Get the file name of the exported artifact */
+  getFileName?(properties: { [name: string]: any }): string;
+  /** Deprecated: get the file extension of the exported artifact */
+  getFileExtension?(properties: { [name: string]: any }): string;
   /** Generate the exported template, return a base64 string encoding the file */
   generate(properties: { [name: string]: any }): Promise<string>;
 }

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -96,3 +96,44 @@ export function renderDataURLToPNG(
     };
   });
 }
+
+export function readFileAsString(file: File): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      resolve(reader.result as string);
+    };
+    reader.onerror = () => {
+      reject(new Error(`unable to read file ${file.name}`));
+    };
+    reader.readAsText(file, "utf-8");
+  });
+}
+
+export function getExtensionFromFileName(filename: string) {
+  const m = filename.match(/\.([^\.]+)$/);
+  if (m) {
+    return m[1].toLowerCase();
+  } else {
+    return null;
+  }
+}
+
+export function getFileNameWithoutExtension(filename: string) {
+  return filename.replace(/\.([^\.]+)$/, "");
+}
+
+export function showOpenFileDialog(accept?: string[]): Promise<File> {
+  return new Promise<File>((resolve, reject) => {
+    const inputElement = document.createElement("input");
+    inputElement.type = "file";
+    inputElement.onchange = e => {
+      if (inputElement.files.length == 1) {
+        resolve(inputElement.files[0]);
+      } else {
+        reject();
+      }
+    };
+    inputElement.click();
+  });
+}

--- a/src/app/views/file_view/export_view.tsx
+++ b/src/app/views/file_view/export_view.tsx
@@ -276,7 +276,14 @@ export class ExportTemplateView extends ContextedComponent<
                   });
                   FileSaver.saveAs(
                     blob,
-                    "charticulator." + this.state.target.getFileExtension()
+                    this.state.target.getFileName
+                      ? this.state.target.getFileName(
+                          this.state.targetProperties
+                        )
+                      : "charticulator." +
+                        this.state.target.getFileExtension(
+                          this.state.targetProperties
+                        )
                   );
                 });
             }}

--- a/src/app/views/file_view/import_data_view.tsx
+++ b/src/app/views/file_view/import_data_view.tsx
@@ -5,37 +5,16 @@ import * as R from "../../resources";
 import * as globals from "../../globals";
 import { getConfig } from "../../config";
 import { Dataset } from "../../../core";
-import { classNames } from "../../utils";
+import {
+  classNames,
+  getExtensionFromFileName,
+  readFileAsString,
+  getFileNameWithoutExtension
+} from "../../utils";
 import { ButtonRaised } from "../../components/index";
 import { SVGImageIcon } from "../../components/icons";
 import { TableView } from "../dataset/table_view";
 import { PopupView } from "../../controllers";
-
-function readFileAsString(file: File): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      resolve(reader.result as string);
-    };
-    reader.onerror = () => {
-      reject(new Error(`unable to read file ${file.name}`));
-    };
-    reader.readAsText(file, "utf-8");
-  });
-}
-
-function getExtension(filename: string) {
-  const m = filename.match(/\.([^\.]+)$/);
-  if (m) {
-    return m[1].toLowerCase();
-  } else {
-    return null;
-  }
-}
-
-function getFileNameWithoutExtension(filename: string) {
-  return filename.replace(/\.([^\.]+)$/, "");
-}
 
 export interface FileUploaderProps {
   onChange: (file: File) => void;
@@ -96,7 +75,7 @@ export class FileUploader extends React.Component<
     if (dt && dt.items.length == 1) {
       if (dt.items[0].kind == "file") {
         const file = dt.items[0].getAsFile();
-        const ext = getExtension(file.name);
+        const ext = getExtensionFromFileName(file.name);
         if (this.props.extensions.indexOf(ext) >= 0) {
           return file;
         } else {
@@ -199,7 +178,7 @@ export class ImportDataView extends React.Component<
   }
   private loadFileAsTable(file: File): Promise<Dataset.Table> {
     return readFileAsString(file).then(contents => {
-      const ext = getExtension(file.name);
+      const ext = getExtensionFromFileName(file.name);
       const filename = getFileNameWithoutExtension(file.name);
       const loader = new Dataset.DatasetLoader();
       switch (ext) {

--- a/src/app/views/panels/widgets/manager.tsx
+++ b/src/app/views/panels/widgets/manager.tsx
@@ -28,7 +28,11 @@ import {
 } from "../../../controllers/drag_controller";
 
 import { ChartStore } from "../../../stores";
-import { classNames } from "../../../utils/index";
+import {
+  classNames,
+  showOpenFileDialog,
+  readFileAsString
+} from "../../../utils/index";
 import { DataFieldSelector } from "../../dataset/data_field_selector";
 import { ReorderListView } from "../object_list_editor";
 import {
@@ -40,11 +44,13 @@ import {
   InputText,
   Radio,
   Select,
-  ComboBoxFontFamily
+  ComboBoxFontFamily,
+  InputFile
 } from "./controls";
 import { FilterEditor } from "./filter_editor";
 import { MappingEditor } from "./mapping_editor";
 import { GroupByEditor } from "./groupby_editor";
+import { ChartTemplate } from "../../../../container";
 
 export type OnEditMappingHandler = (
   attribute: string,
@@ -724,46 +730,70 @@ export class WidgetManager implements Prototypes.Controls.WidgetManager {
   ) {
     return this.row(
       "",
-      <ButtonRaised
-        text="Edit Nested Chart"
-        onClick={() => {
-          const editorID = uniqueID();
-          const newWindow = window.open(
-            "index.html#!nestedEditor=" + editorID,
-            "nested_chart_" + options.specification._id
-          );
-          const listener = (e: MessageEvent) => {
-            if (e.origin == document.location.origin) {
-              const data = e.data;
-              if (data.id == editorID) {
-                switch (data.type) {
-                  case "initialized":
-                    {
-                      newWindow.postMessage(
-                        {
-                          id: editorID,
-                          type: "load",
-                          specification: options.specification,
-                          dataset: options.dataset,
-                          width: options.width,
-                          height: options.height
-                        },
-                        document.location.origin
-                      );
-                    }
-                    break;
-                  case "save":
-                    {
-                      this.emitSetProperty(property, data.specification);
-                    }
-                    break;
+      this.vertical(
+        <ButtonRaised
+          text="Edit Nested Chart..."
+          onClick={() => {
+            const editorID = uniqueID();
+            const newWindow = window.open(
+              "index.html#!nestedEditor=" + editorID,
+              "nested_chart_" + options.specification._id
+            );
+            const listener = (e: MessageEvent) => {
+              if (e.origin == document.location.origin) {
+                const data = e.data;
+                if (data.id == editorID) {
+                  switch (data.type) {
+                    case "initialized":
+                      {
+                        newWindow.postMessage(
+                          {
+                            id: editorID,
+                            type: "load",
+                            specification: options.specification,
+                            dataset: options.dataset,
+                            width: options.width,
+                            height: options.height
+                          },
+                          document.location.origin
+                        );
+                      }
+                      break;
+                    case "save":
+                      {
+                        this.emitSetProperty(property, data.specification);
+                      }
+                      break;
+                  }
                 }
               }
-            }
-          };
-          window.addEventListener("message", listener);
-        }}
-      />
+            };
+            window.addEventListener("message", listener);
+          }}
+        />,
+        <div style={{ marginTop: "5px" }}>
+          <ButtonRaised
+            text="Import Template..."
+            onClick={async () => {
+              const file = await showOpenFileDialog(["json"]);
+              const str = await readFileAsString(file);
+              const data = JSON.parse(str);
+              const template = new ChartTemplate(data);
+              for (const table of options.dataset.tables) {
+                const tTable = template.getDatasetSchema()[0];
+                template.assignTable(tTable.name, table.name);
+                for (const column of tTable.columns) {
+                  template.assignColumn(tTable.name, column.name, column.name);
+                }
+              }
+              this.emitSetProperty(property, template.instantiate(
+                options.dataset,
+                false // no scale inference
+              ) as any);
+            }}
+          />
+        </div>
+      )
     );
   }
 

--- a/src/container/chart_template.ts
+++ b/src/container/chart_template.ts
@@ -91,7 +91,10 @@ export class ChartTemplate {
     }
   }
 
-  public instantiate(dataset: Dataset.Dataset): Specification.Chart {
+  public instantiate(
+    dataset: Dataset.Dataset,
+    inference: boolean = true
+  ): Specification.Chart {
     // Make a copy of the chart spec so we won't touch the original template data
     const chart = deepClone(this.template.specification);
 
@@ -178,6 +181,9 @@ export class ChartTemplate {
           textMapping.table = this.tableAssignment[textMapping.table];
         }
       }
+    }
+    if (!inference) {
+      return chart;
     }
 
     const df = new Prototypes.Dataflow.DataflowManager(dataset);


### PR DESCRIPTION
- Add a button in the nested chart's property panel to allow importing a charticulator template
- Enable the charticulator template export option for production mode
- A `inference` parameter is added to `ChartTemplate.instantiate`, allowing us to disable scale inference on importing for nested chart
- Allow a template exporter extension to decide the filename of the exported artifact
- Fix issue in gradient picker (Chrome-only bug) - this is a backport from another branch
