### PR TITLE
Solver enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "d3-time-format": "^2.1.1",
     "file-saver": "1.3.8",
     "hammerjs": "2.0.8",
-    "lscg-solver": "^1.1.1",
+    "lscg-solver": "^1.2.0",
     "react": "16.3.2",
     "react-dom": "16.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "d3-time-format": "^2.1.1",
     "file-saver": "1.3.8",
     "hammerjs": "2.0.8",
-    "lscg-solver": "^1.1.0",
+    "lscg-solver": "^1.1.1",
     "react": "16.3.2",
     "react-dom": "16.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "d3-time-format": "^2.1.1",
     "file-saver": "1.3.8",
     "hammerjs": "2.0.8",
-    "lscg-solver": "1.0.1",
+    "lscg-solver": "^1.1.0",
     "react": "16.3.2",
     "react-dom": "16.3.2"
   },

--- a/src/app/stores/chart.ts
+++ b/src/app/stores/chart.ts
@@ -1257,7 +1257,7 @@ export class ChartStore extends BaseStore {
               }
               markState.attributes[key] = action.updates[key];
               this.addPresolveValue(
-                Solver.ConstraintStrength.STRONG,
+                Solver.ConstraintStrength.WEAK,
                 markState.attributes,
                 key,
                 action.updates[key] as number

--- a/src/app/views/canvas/mark_editor.tsx
+++ b/src/app/views/canvas/mark_editor.tsx
@@ -82,6 +82,11 @@ export class MarkEditorView extends ContextedComponent<
       )
     );
     this.subs.push(
+      chartStore.addListener(ChartStore.EVENT_SELECTION, () =>
+        this.forceUpdate()
+      )
+    );
+    this.subs.push(
       chartStore.addListener(ChartStore.EVENT_CURRENT_TOOL, () => {
         this.setState({
           currentCreation: chartStore.currentTool,

--- a/src/container/chart_component.tsx
+++ b/src/container/chart_component.tsx
@@ -62,18 +62,7 @@ export class ChartComponent extends React.Component<
     this.recreateManager(props);
     this.updateWithNewProps(props);
     if (props.sync) {
-      {
-        const solver = new Solver.ChartConstraintSolver("chart");
-        solver.setup(this.manager);
-        solver.solve();
-        solver.destroy();
-      }
-      {
-        const solver = new Solver.ChartConstraintSolver("glyphs");
-        solver.setup(this.manager);
-        solver.solve();
-        solver.destroy();
-      }
+      this.manager.solveConstraints();
 
       this.state = {
         working: false,

--- a/src/container/chart_component.tsx
+++ b/src/container/chart_component.tsx
@@ -181,18 +181,7 @@ export class ChartComponent extends React.Component<
     }
     this.timer = setTimeout(() => {
       this.timer = null;
-      {
-        const solver = new Solver.ChartConstraintSolver("chart");
-        solver.setup(this.manager);
-        solver.solve();
-        solver.destroy();
-      }
-      {
-        const solver = new Solver.ChartConstraintSolver("glyphs");
-        solver.setup(this.manager);
-        solver.solve();
-        solver.destroy();
-      }
+      this.manager.solveConstraints();
       this.applySelection(this.props.selection);
       this.setState({
         working: false,

--- a/src/container/chart_component.tsx
+++ b/src/container/chart_component.tsx
@@ -62,12 +62,19 @@ export class ChartComponent extends React.Component<
     this.recreateManager(props);
     this.updateWithNewProps(props);
     if (props.sync) {
-      for (let i = 0; i < 2; i++) {
-        const solver = new Solver.ChartConstraintSolver();
+      {
+        const solver = new Solver.ChartConstraintSolver("chart");
         solver.setup(this.manager);
         solver.solve();
         solver.destroy();
       }
+      {
+        const solver = new Solver.ChartConstraintSolver("glyphs");
+        solver.setup(this.manager);
+        solver.solve();
+        solver.destroy();
+      }
+
       this.state = {
         working: false,
         graphics: this.renderer.render()
@@ -174,8 +181,14 @@ export class ChartComponent extends React.Component<
     }
     this.timer = setTimeout(() => {
       this.timer = null;
-      for (let i = 0; i < 2; i++) {
-        const solver = new Solver.ChartConstraintSolver();
+      {
+        const solver = new Solver.ChartConstraintSolver("chart");
+        solver.setup(this.manager);
+        solver.solve();
+        solver.destroy();
+      }
+      {
+        const solver = new Solver.ChartConstraintSolver("glyphs");
         solver.setup(this.manager);
         solver.solve();
         solver.destroy();

--- a/src/core/prototypes/charts/index.ts
+++ b/src/core/prototypes/charts/index.ts
@@ -138,6 +138,8 @@ class RectangleChart extends ChartClass {
     "y1",
     "x2",
     "y2",
+    "cx",
+    "cy",
     "ox1",
     "oy1",
     "ox2",
@@ -164,6 +166,14 @@ class RectangleChart extends ChartClass {
     },
     y2: {
       name: "y2",
+      type: Specification.AttributeType.Number
+    },
+    cx: {
+      name: "cx",
+      type: Specification.AttributeType.Number
+    },
+    cy: {
+      name: "cy",
       type: Specification.AttributeType.Number
     },
     ox1: {

--- a/src/core/prototypes/plot_segments/line.ts
+++ b/src/core/prototypes/plot_segments/line.ts
@@ -90,7 +90,7 @@ export class LineGuide extends PlotSegmentClass {
     attrs.y2 = 100;
   }
 
-  public buildConstraints(solver: ConstraintSolver): void {
+  public buildGlyphConstraints(solver: ConstraintSolver): void {
     const chart = this.parent.object;
     const props = this.object.properties;
     const rows = this.parent.dataflow.getTable(this.object.table);

--- a/src/core/prototypes/plot_segments/map/map.ts
+++ b/src/core/prototypes/plot_segments/map/map.ts
@@ -96,7 +96,7 @@ export class MapPlotSegment extends PlotSegmentClass {
     attrs.y2 = 100;
   }
 
-  public buildConstraints(solver: ConstraintSolver): void {
+  public buildGlyphConstraints(solver: ConstraintSolver): void {
     const [latitude, longitude, zoom] = this.getCenterZoom();
     const longitudeData = this.object.properties.longitudeData;
     const latitudeData = this.object.properties.latitudeData;

--- a/src/core/prototypes/plot_segments/plot_segment.ts
+++ b/src/core/prototypes/plot_segments/plot_segment.ts
@@ -17,8 +17,14 @@ export abstract class PlotSegmentClass<
   /** Fill the layout's default state */
   public initializeState(): void {}
 
-  /** Get intrinsic constraints between attributes (e.g., x2 - x1 = width for rectangles) */
+  /** Build intrinsic constraints between attributes (e.g., x2 - x1 = width for rectangles) */
   public buildConstraints(
+    solver: ConstraintSolver,
+    context: BuildConstraintsContext
+  ): void {}
+
+  /** Build constraints for glyphs within */
+  public buildGlyphConstraints(
     solver: ConstraintSolver,
     context: BuildConstraintsContext
   ): void {}

--- a/src/core/prototypes/plot_segments/region_2d/cartesian.ts
+++ b/src/core/prototypes/plot_segments/region_2d/cartesian.ts
@@ -192,7 +192,7 @@ export class CartesianPlotSegment extends PlotSegmentClass<
     return builder;
   }
 
-  public buildConstraints(
+  public buildGlyphConstraints(
     solver: ConstraintSolver,
     context: BuildConstraintsContext
   ): void {

--- a/src/core/prototypes/plot_segments/region_2d/cartesian.ts
+++ b/src/core/prototypes/plot_segments/region_2d/cartesian.ts
@@ -118,7 +118,16 @@ export class CartesianPlotSegment extends PlotSegmentClass<
 
   public readonly state: CartesianState;
 
-  public attributeNames: string[] = ["x1", "x2", "y1", "y2", "gapX", "gapY"];
+  public attributeNames: string[] = [
+    "x1",
+    "x2",
+    "y1",
+    "y2",
+    "x",
+    "y",
+    "gapX",
+    "gapY"
+  ];
   public attributes: { [name: string]: AttributeDescription } = {
     x1: {
       name: "x1",

--- a/src/core/prototypes/plot_segments/region_2d/curve.ts
+++ b/src/core/prototypes/plot_segments/region_2d/curve.ts
@@ -287,7 +287,12 @@ export class CurvePlotSegment extends PlotSegmentClass<
       [[1, normal2]],
       [[props.normalEnd / 2, x2], [-props.normalEnd / 2, x1]]
     );
+  }
 
+  public buildGlyphConstraints(
+    solver: ConstraintSolver,
+    context: BuildConstraintsContext
+  ): void {
     const builder = this.createBuilder(solver, context);
     builder.build();
   }

--- a/src/core/prototypes/plot_segments/region_2d/polar.ts
+++ b/src/core/prototypes/plot_segments/region_2d/polar.ts
@@ -240,24 +240,13 @@ export class PolarPlotSegment extends PlotSegmentClass<
     const attrs = this.state.attributes;
     const props = this.object.properties;
 
-    const [
-      x1,
-      y1,
-      x2,
-      y2,
-      innerRadius,
-      outerRadius,
-      angle1,
-      angle2
-    ] = solver.attrs(attrs, [
+    const [x1, y1, x2, y2, innerRadius, outerRadius] = solver.attrs(attrs, [
       "x1",
       "y1",
       "x2",
       "y2",
       "radial1",
-      "radial2",
-      "angle1",
-      "angle2"
+      "radial2"
     ]);
 
     attrs.angle1 = props.startAngle;
@@ -265,10 +254,9 @@ export class PolarPlotSegment extends PlotSegmentClass<
     solver.makeConstant(attrs, "angle1");
     solver.makeConstant(attrs, "angle2");
 
-    const minRatio = Math.min(props.innerRatio, props.outerRatio);
-    const maxRatio = Math.max(props.innerRatio, props.outerRatio);
-
     if (attrs.x2 - attrs.x1 < attrs.y2 - attrs.y1) {
+      attrs.radial1 = (props.innerRatio * (attrs.x2 - attrs.x1)) / 2;
+      attrs.radial2 = (props.outerRatio * (attrs.x2 - attrs.x1)) / 2;
       solver.addLinear(
         ConstraintStrength.HARD,
         0,
@@ -282,6 +270,8 @@ export class PolarPlotSegment extends PlotSegmentClass<
         [[2, outerRadius]]
       );
     } else {
+      attrs.radial1 = (props.innerRatio * (attrs.y2 - attrs.y1)) / 2;
+      attrs.radial2 = (props.outerRatio * (attrs.y2 - attrs.y1)) / 2;
       solver.addLinear(
         ConstraintStrength.HARD,
         0,
@@ -295,7 +285,12 @@ export class PolarPlotSegment extends PlotSegmentClass<
         [[2, outerRadius]]
       );
     }
+  }
 
+  public buildGlyphConstraints(
+    solver: ConstraintSolver,
+    context: BuildConstraintsContext
+  ): void {
     const builder = this.createBuilder(solver, context);
     builder.build();
   }

--- a/src/core/solver/abstract.ts
+++ b/src/core/solver/abstract.ts
@@ -35,8 +35,16 @@ export abstract class ConstraintSolver {
   /** Set the value of a variable */
   public abstract setValue(attr: Variable, value: number): void;
 
-  /** Add a linear constraint */
+  /** Add a linear constraint: bias + linear(lhs) == linear(rhs) */
   public abstract addLinear(
+    strength: ConstraintStrength,
+    bias: number,
+    lhs: Array<[number, Variable]>,
+    rhs?: Array<[number, Variable]>
+  ): void;
+
+  /** Add a soft inequality constraint: bias + linear(lhs) >= linear(rhs) */
+  public abstract addSoftInequality(
     strength: ConstraintStrength,
     bias: number,
     lhs: Array<[number, Variable]>,

--- a/src/core/solver/index.ts
+++ b/src/core/solver/index.ts
@@ -7,17 +7,11 @@ import {
   ConstraintStrength,
   Variable
 } from "./abstract";
-import {
-  ChartConstraintSolver,
-  GlyphConstraintAnalyzer,
-  GlyphConstraintSolver
-} from "./solver";
-// import { CGConstraintSolver, ConstraintCompiler } from "./cg_solver";
+import { ChartConstraintSolver, GlyphConstraintAnalyzer } from "./solver";
 
 export {
   ChartConstraintSolver,
   GlyphConstraintAnalyzer,
-  GlyphConstraintSolver,
   ConstraintSolver,
   AttributeOptions,
   ConstraintStrength,

--- a/src/core/solver/solver.ts
+++ b/src/core/solver/solver.ts
@@ -8,11 +8,11 @@ import * as Specification from "../specification";
 
 import { getById, KeyNameMap, uniqueID, zip } from "../common";
 import { ConstraintSolver, ConstraintStrength, Variable } from "./abstract";
-import { Matrix, WASMSolver as MyConstraintSolver } from "./wasm_solver";
+import { Matrix, WASMSolver } from "./wasm_solver";
 
 /** Solves constraints in the scope of a chart */
 export class ChartConstraintSolver {
-  public solver: MyConstraintSolver;
+  public solver: WASMSolver;
   public stage: "chart" | "glyphs";
 
   public chart: Specification.Chart;
@@ -23,12 +23,13 @@ export class ChartConstraintSolver {
   public expressionCache: Expression.ExpressionCache;
 
   /** Create a ChartConstraintSolver
+   * - stage == "chart": disregard glyphs, solve chart-level constraints
+   * - stage == "glyphs": fix chart-level attributes, solve only glyphs
    * @param stage determines the scope of the variables to solve
    */
   constructor(stage: "chart" | "glyphs") {
-    this.solver = new MyConstraintSolver();
+    this.solver = new WASMSolver();
     this.stage = stage;
-    console.log("Solver: ", stage);
   }
 
   public setManager(manager: Prototypes.ChartStateManager) {
@@ -272,11 +273,11 @@ export class ChartConstraintSolver {
 
     const glyphClass = this.manager.getGlyphClass(glyphState);
     for (const attr of glyphClass.attributeNames) {
-      const info = glyphClass.attributes[attr];
-      if (info.solverExclude) {
-        continue;
-      }
-      this.addAttribute(glyphState.attributes, attr, true);
+      // const info = glyphClass.attributes[attr];
+      // if (info.solverExclude) {
+      //   continue;
+      // }
+      // this.addAttribute(glyphState.attributes, attr, true);
 
       // If width/height are not constrained, make them constant
       if (attr == "width" && glyphAnalyzed.widthFree) {

--- a/src/core/solver/solver.ts
+++ b/src/core/solver/solver.ts
@@ -527,6 +527,22 @@ export class GlyphConstraintAnalyzer extends ConstraintSolver {
     ]);
   }
 
+  public addSoftInequality(
+    strength: ConstraintStrength,
+    bias: number,
+    lhs: Array<[number, { index: number }]>,
+    rhs: Array<[number, { index: number }]> = []
+  ) {
+    this.linears.push([
+      bias,
+      lhs
+        .map(([weight, obj]) => ({ weight, index: obj.index }))
+        .concat(
+          rhs.map(([weight, obj]) => ({ weight: -weight, index: obj.index }))
+        )
+    ]);
+  }
+
   public addInputAttribute(name: string, attr: { index: number }) {
     if (this.inputBiases.has(name)) {
       const idx = this.inputBiases.get(name).index;

--- a/src/core/solver/wasm_solver.ts
+++ b/src/core/solver/wasm_solver.ts
@@ -133,15 +133,14 @@ export class WASMSolver extends ConstraintSolver {
     });
   }
 
-  private _count = 0;
-
   /** Solve the constraints */
   public solve(): [number, number] {
     this.variables.forEach((value, map, key) => {
       this.solver.setValue(value.index, map[key] as number);
     });
 
-    for (let iter = 0; iter < 10; iter++) {
+    const maxIters = 10;
+    for (let iter = 0; iter < maxIters; iter++) {
       this.solver.solve();
       let shouldReiterate = false;
       for (const soft of this.softInequalities) {
@@ -162,8 +161,10 @@ export class WASMSolver extends ConstraintSolver {
       if (!shouldReiterate) {
         break;
       }
-      if (iter == 9) {
-        console.warn("Soft inequalities didn't converge within 10 iterations");
+      if (iter == maxIters - 1) {
+        console.warn(
+          `Soft inequalities didn't converge within ${maxIters} iterations`
+        );
       }
     }
 

--- a/src/core/solver/wasm_solver.ts
+++ b/src/core/solver/wasm_solver.ts
@@ -68,7 +68,14 @@ export class WASMSolver extends ConstraintSolver {
       if (isNaN(value)) {
         value = 0;
       }
-      this.solver.addVariable(this.currentIndex, value, true);
+      this.solver.addVariable(
+        this.currentIndex,
+        value,
+        options ? options.edit : false
+      );
+      if (!options) {
+        console.warn(`Creating new attr ${name} without options`);
+      }
       return item;
     }
   }

--- a/src/core/solver/wasm_solver.ts
+++ b/src/core/solver/wasm_solver.ts
@@ -142,24 +142,14 @@ export class WASMSolver extends ConstraintSolver {
 
   /** Solve the constraints */
   public solve(): [number, number] {
-    const keeps: Array<[number, number]> = [];
     this.variables.forEach((value, map, key) => {
       this.solver.setValue(value.index, map[key] as number);
-      // Try to keep the original values of variables
-      const c = this.solver.addConstraint(
-        LSCGSolver.ConstraintSolver.STRENGTH_WEAKER,
-        map[key] as number,
-        [value.index],
-        [-1]
-      );
-      keeps.push([c, value.index]);
     });
+
+    this.solver.regularizerWeight = 0.001;
 
     const maxIters = 10;
     for (let iter = 0; iter < maxIters; iter++) {
-      for (const [c, index] of keeps) {
-        this.solver.setConstraintBias(c, this.solver.getValue(index));
-      }
       this.solver.solve();
       let shouldReiterate = false;
       for (const soft of this.softInequalities) {

--- a/src/worker/worker_main.ts
+++ b/src/worker/worker_main.ts
@@ -77,6 +77,7 @@ class CharticulatorWorkerProcess extends WorkerHostProcess {
       const iterations = additional != null ? 2 : 1;
       for (let i = 0; i < iterations; i++) {
         {
+          const t1 = new Date().getTime();
           const solver = new Core.Solver.ChartConstraintSolver("chart");
           solver.setup(chartManager);
           if (additional) {
@@ -84,8 +85,11 @@ class CharticulatorWorkerProcess extends WorkerHostProcess {
           }
           loss = solver.solve();
           solver.destroy();
+          const t2 = new Date().getTime();
+          console.log("chart phase", t2 - t1);
         }
         {
+          const t1 = new Date().getTime();
           const solver = new Core.Solver.ChartConstraintSolver("glyphs");
           solver.setup(chartManager);
           if (additional) {
@@ -93,6 +97,8 @@ class CharticulatorWorkerProcess extends WorkerHostProcess {
           }
           loss = solver.solve();
           solver.destroy();
+          const t2 = new Date().getTime();
+          console.log("glyphs phase", t2 - t1);
         }
         additional = null;
       }

--- a/src/worker/worker_main.ts
+++ b/src/worker/worker_main.ts
@@ -63,46 +63,12 @@ class CharticulatorWorkerProcess extends WorkerHostProcess {
     additional: (solver: Core.Solver.ChartConstraintSolver) => void = null,
     mappingOnly: boolean = false
   ) {
-    let loss: { softLoss: number; hardLoss: number } = null;
     const chartManager = new Core.Prototypes.ChartStateManager(
       chart,
       dataset,
       chartState
     );
-    if (mappingOnly) {
-      const solver = new Core.Solver.ChartConstraintSolver("glyphs");
-      solver.setup(chartManager);
-      solver.destroy();
-    } else {
-      const iterations = additional != null ? 2 : 1;
-      for (let i = 0; i < iterations; i++) {
-        {
-          const t1 = new Date().getTime();
-          const solver = new Core.Solver.ChartConstraintSolver("chart");
-          solver.setup(chartManager);
-          if (additional) {
-            additional(solver);
-          }
-          loss = solver.solve();
-          solver.destroy();
-          const t2 = new Date().getTime();
-          console.log("chart phase", t2 - t1);
-        }
-        {
-          const t1 = new Date().getTime();
-          const solver = new Core.Solver.ChartConstraintSolver("glyphs");
-          solver.setup(chartManager);
-          if (additional) {
-            additional(solver);
-          }
-          loss = solver.solve();
-          solver.destroy();
-          const t2 = new Date().getTime();
-          console.log("glyphs phase", t2 - t1);
-        }
-        additional = null;
-      }
-    }
+    chartManager.solveConstraints(additional, mappingOnly);
     return chartState;
   }
 }

--- a/src/worker/worker_main.ts
+++ b/src/worker/worker_main.ts
@@ -64,7 +64,7 @@ class CharticulatorWorkerProcess extends WorkerHostProcess {
     mappingOnly: boolean = false
   ) {
     let loss: { softLoss: number; hardLoss: number } = null;
-    let iterations = additional != null ? 2 : 2;
+    let iterations = additional != null ? 2 : 1;
     if (mappingOnly) {
       iterations = 1;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,9 +2537,9 @@ lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lscg-solver@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/lscg-solver/-/lscg-solver-1.1.1.tgz#3b5d3b9183106e8551f18e5147af2b3fe7034463"
+lscg-solver@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/lscg-solver/-/lscg-solver-1.2.0.tgz#c836ba198025f59431081a75eb031758f2d84b4e"
 
 make-dir@^1.0.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,9 +2537,9 @@ lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lscg-solver@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/lscg-solver/-/lscg-solver-1.1.0.tgz#f8eeff5714612b87352dd63d4fd0b84c0df27b24"
+lscg-solver@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/lscg-solver/-/lscg-solver-1.1.1.tgz#3b5d3b9183106e8551f18e5147af2b3fe7034463"
 
 make-dir@^1.0.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,9 +2537,9 @@ lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lscg-solver@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/lscg-solver/-/lscg-solver-1.0.1.tgz#b3e6c98c3b8a294d224a18ce1888e4a2db42e444"
+lscg-solver@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/lscg-solver/-/lscg-solver-1.1.0.tgz#f8eeff5714612b87352dd63d4fd0b84c0df27b24"
 
 make-dir@^1.0.0:
   version "1.3.0"


### PR DESCRIPTION
Upgrade `lscg-solver` to `1.2.0`, and make the following enhancements related to the solver:
- A better approach to fit marks to plot segment boundaries. Previously we had to run the whole solver process twice (which was the bottleneck), now we only need to execute the `lscg-solver` a few times
- Solve the charts in two stages: in `chart` stage, we layout chart-level elements, and then in `glyphs` stage, we layout glyphs, while keeping chart-level elements intact. This is to address the problems where de-snapping a plot segment may result in unexpected behavior
- Add a regularizer to keep unconstrained variables to their current value in case the algorithms gives something completely different, and generate unexpected behavior