### PR TITLE
Fix issues related to guides and guide coordinators

### DIFF
--- a/src/app/stores/chart.ts
+++ b/src/app/stores/chart.ts
@@ -708,6 +708,9 @@ export class ChartStore extends BaseStore {
         }
       }
 
+      this.currentSelection = new ChartElementSelection(newPlotSegment);
+      this.emit(ChartStore.EVENT_SELECTION);
+
       this.solveConstraintsAndUpdateGraphics();
     }
 
@@ -813,6 +816,14 @@ export class ChartStore extends BaseStore {
           gap: 0
         }
       });
+
+      this.addPresolveValue(
+        Solver.ConstraintStrength.STRONG,
+        this.chartManager.getClassById(action.element._id).state.attributes,
+        action.attribute,
+        this.chartManager.getClassById(action.targetElement._id).state
+          .attributes[action.targetAttribute] as number
+      );
 
       this.solveConstraintsAndUpdateGraphics();
     }

--- a/src/app/views/canvas/chart_editor.tsx
+++ b/src/app/views/canvas/chart_editor.tsx
@@ -425,7 +425,7 @@ export class ChartEditorView
               new Actions.AddPlotSegment(
                 "guide.guide-coordinator",
                 { x1, y1, x2, y2 },
-                { axis: "x", count: 3 }
+                { axis: "x", count: 4 }
               ).dispatch(this.props.store.dispatcher);
             };
           }
@@ -437,7 +437,7 @@ export class ChartEditorView
               new Actions.AddPlotSegment(
                 "guide.guide-coordinator",
                 { x1, y1, x2, y2 },
-                { axis: "y", count: 3 }
+                { axis: "y", count: 4 }
               ).dispatch(this.props.store.dispatcher);
             };
           }

--- a/src/app/views/canvas/mark_editor.tsx
+++ b/src/app/views/canvas/mark_editor.tsx
@@ -1250,7 +1250,7 @@ export class SingleMarkView
                   "guide.guide-coordinator",
                   { x: 0, y: 0 },
                   { x1, y1, x2, y2 },
-                  { axis: "x", count: 3 }
+                  { axis: "x", count: 4 }
                 )
               );
             };
@@ -1266,7 +1266,7 @@ export class SingleMarkView
                   "guide.guide-coordinator",
                   { x: 0, y: 0 },
                   { x1, y1, x2, y2 },
-                  { axis: "y", count: 3 }
+                  { axis: "y", count: 4 }
                 )
               );
             };

--- a/src/core/prototypes/guides/index.ts
+++ b/src/core/prototypes/guides/index.ts
@@ -4,7 +4,13 @@
 import { ConstraintSolver, ConstraintStrength, Variable } from "../../solver";
 import * as Specification from "../../specification";
 import { ChartElementClass } from "../chart_element";
-import { AttributeDescription, Handles, SnappingGuides } from "../common";
+import {
+  AttributeDescription,
+  Handles,
+  SnappingGuides,
+  BoundingBox,
+  Controls
+} from "../common";
 import { ObjectClassMetadata } from "../index";
 import { ObjectClasses } from "../object";
 
@@ -12,11 +18,15 @@ export interface GuideAttributes extends Specification.AttributeMap {
   value: number;
 }
 
-export interface GuideState extends Specification.ObjectState {
-  attributes: GuideAttributes;
+export interface GuideProperties extends Specification.AttributeMap {
+  axis: "x" | "y";
+  gap: number;
 }
 
-export class GuideClass extends ChartElementClass {
+export class GuideClass extends ChartElementClass<
+  GuideProperties,
+  GuideAttributes
+> {
   public static classID = "guide.guide";
   public static type = "guide";
 
@@ -25,32 +35,46 @@ export class GuideClass extends ChartElementClass {
     iconPath: "guide/x"
   };
 
-  public readonly state: GuideState;
-
-  public static defaultAttributes: Specification.AttributeMap = {
-    axis: "x"
+  public static defaultProperties: Partial<GuideProperties> = {
+    gap: 0
   };
 
-  public attributeNames: string[] = ["value"];
+  public attributeNames: string[] = ["value", "value2"];
   public attributes: { [name: string]: AttributeDescription } = {
     value: {
       name: "value",
+      type: Specification.AttributeType.Number
+    },
+    value2: {
+      name: "value2",
       type: Specification.AttributeType.Number
     }
   };
 
   public initializeState() {
     this.state.attributes.value = 0;
+    this.state.attributes.value2 = 0;
   }
 
   private getAxis() {
-    return this.object.properties.axis as "x" | "y";
+    return this.object.properties.axis;
+  }
+
+  public buildConstraints(solver: ConstraintSolver) {
+    const [value, value2] = solver.attrs(this.state.attributes, [
+      "value",
+      "value2"
+    ]);
+    solver.addLinear(ConstraintStrength.HARD, this.object.properties.gap, [
+      [1, value],
+      [-1, value2]
+    ]);
   }
 
   /** Get handles given current state */
   public getHandles(): Handles.Description[] {
     const inf = [-1000, 1000];
-    return [
+    const r = [
       {
         type: "line",
         axis: this.getAxis(),
@@ -59,10 +83,20 @@ export class GuideClass extends ChartElementClass {
         span: inf
       } as Handles.Line
     ];
+    if (this.object.properties.gap > 0) {
+      r.push({
+        type: "line",
+        axis: this.getAxis(),
+        actions: [{ type: "attribute", attribute: "value2" }],
+        value: this.state.attributes.value2,
+        span: inf
+      } as Handles.Line);
+    }
+    return r;
   }
 
   public getSnappingGuides(): SnappingGuides.Description[] {
-    return [
+    const r = [
       {
         type: this.getAxis(),
         value: this.state.attributes.value,
@@ -70,12 +104,25 @@ export class GuideClass extends ChartElementClass {
         visible: true
       } as SnappingGuides.Axis
     ];
+    if (this.object.properties.gap > 0) {
+      r.push({
+        type: this.getAxis(),
+        value: this.state.attributes.value2,
+        attribute: "value2",
+        visible: true
+      } as SnappingGuides.Axis);
+    }
+    return r;
   }
 
-  // /** Get controls given current state */
-  // public getControls(): Controls.Popup {
-  //     return null;
-  // }
+  public getAttributePanelWidgets(
+    manager: Controls.WidgetManager
+  ): Controls.Widget[] {
+    return [
+      manager.sectionHeader("Guide"),
+      manager.row("Split Gap", manager.inputNumber({ property: "gap" }, {}))
+    ];
+  }
 }
 
 export interface GuideCoordinatorAttributes extends Specification.AttributeMap {
@@ -193,7 +240,57 @@ export class GuideCoordinatorClass extends ChartElementClass {
 
   /** Get handles given current state */
   public getHandles(): Handles.Description[] {
-    return [];
+    const attrs = this.state.attributes as GuideCoordinatorAttributes;
+    const { x1, y1, x2, y2 } = attrs;
+    const axis = this.getAxis();
+    return [
+      {
+        type: "point",
+        x: x1,
+        y: y1,
+        actions: [
+          { type: "attribute", source: "x", attribute: "x1" },
+          { type: "attribute", source: "y", attribute: "y1" }
+        ]
+      } as Handles.Point,
+      {
+        type: "point",
+        x: axis == "y" ? x1 : x2,
+        y: axis == "x" ? y1 : y2,
+        actions: [
+          {
+            type: "attribute",
+            source: "x",
+            attribute: axis == "y" ? "x1" : "x2"
+          },
+          {
+            type: "attribute",
+            source: "y",
+            attribute: axis == "x" ? "y1" : "y2"
+          }
+        ]
+      } as Handles.Point
+    ];
+  }
+
+  public getBoundingBox(): BoundingBox.Description {
+    const attrs = this.state.attributes as GuideCoordinatorAttributes;
+    const { x1, y1 } = attrs;
+    let { x2, y2 } = attrs;
+    if (this.getAxis() == "x") {
+      y2 = y1;
+    } else {
+      x2 = x1;
+    }
+    return {
+      type: "line",
+      visible: true,
+      morphing: true,
+      x1,
+      y1,
+      x2,
+      y2
+    } as BoundingBox.Line;
   }
 
   public getSnappingGuides(): SnappingGuides.Description[] {
@@ -207,10 +304,27 @@ export class GuideCoordinatorClass extends ChartElementClass {
     });
   }
 
-  // /** Get controls given current state */
-  // public getControls(): Controls.Popup {
-  //     return null;
-  // }
+  /** Get controls given current state */
+  public getAttributePanelWidgets(
+    manager: Controls.WidgetManager
+  ): Controls.Widget[] {
+    return [
+      manager.sectionHeader("Guide Coordinator"),
+      manager.row(
+        "Count",
+        manager.inputNumber(
+          { property: "count" },
+          {
+            showUpdown: true,
+            updownTick: 1,
+            updownRange: [1, 100],
+            minimum: 1,
+            maximum: 100
+          }
+        )
+      )
+    ];
+  }
 }
 
 export function registerClasses() {

--- a/src/core/prototypes/object.ts
+++ b/src/core/prototypes/object.ts
@@ -83,12 +83,7 @@ export abstract class ObjectClass<
   public getAttributePanelWidgets(
     manager: Controls.WidgetManager
   ): Controls.Widget[] {
-    // By default, we create the attribute controls based on attribute descriptions
-    const widgets: Controls.Widget[] = [];
-    for (const attr of this.attributeNames) {
-      widgets.push(manager.text("Not implemented yet"));
-    }
-    return widgets;
+    return [manager.text("No editable attribute")];
   }
 
   public getTemplateParameters(): TemplateParameters {


### PR DESCRIPTION
- Add attribute panel widgets for guides and guide coordinators
- Change default number of guides in guide coordinators to 4, to not have an overlap with the existing central guide
- Not implemented yet should be shown only once; changed wording to "No editable attribute"
- Fix a bug with snapping in chart editor, as below, when snapping the top rect to the bottom, the bottom gets enlarged. The correct behavior should be the top gets enlarged.

![2018-09-21 20 51 47](https://user-images.githubusercontent.com/1595237/45913031-32f45f00-bde0-11e8-958f-e6470400e4b4.gif)
