### PR TITLE
Rename Rectangle to Shape

### DIFF
--- a/src/app/views/tool_bar.tsx
+++ b/src/app/views/tool_bar.tsx
@@ -51,13 +51,13 @@ export class Toolbar extends React.Component<ToolbarProps, {}> {
               classID: "mark.rect",
               title: "Ellipse",
               icon: "mark/ellipse",
-              options: '{"shape":"ellipse","name":"Ellipse"}'
+              options: '{"shape":"ellipse"}'
             },
             {
               classID: "mark.rect",
               title: "Triangle",
               icon: "mark/triangle",
-              options: '{"shape":"triangle","name":"Triangle"}'
+              options: '{"shape":"triangle"}'
             }
           ]}
         />

--- a/src/core/prototypes/marks/rect.ts
+++ b/src/core/prototypes/marks/rect.ts
@@ -32,7 +32,7 @@ export class RectElementClass extends EmphasizableMarkClass<
   public static type = "mark";
 
   public static metadata: ObjectClassMetadata = {
-    displayName: "Rectangle",
+    displayName: "Shape",
     iconPath: "mark/rect",
     creatingInteraction: {
       type: "rectangle",


### PR DESCRIPTION
Per offline discussion: now the "Rectangle" can change shape, so it's better to consistently use "Shape" as its name.