### PR TITLE
Fix regression: defaultValues should be shown when no value is entered

### DIFF
--- a/src/app/views/panels/widgets/manager.tsx
+++ b/src/app/views/panels/widgets/manager.tsx
@@ -83,6 +83,9 @@ export class WidgetManager implements Prototypes.Controls.WidgetManager {
   ): JSX.Element {
     const objectClass = this.objectClass;
     const info = objectClass.attributes[attribute];
+    if (info.defaultValue != null) {
+      options.defaultValue = info.defaultValue;
+    }
     return this.row(
       name,
       <MappingEditor

--- a/src/app/views/panels/widgets/manager.tsx
+++ b/src/app/views/panels/widgets/manager.tsx
@@ -83,7 +83,7 @@ export class WidgetManager implements Prototypes.Controls.WidgetManager {
   ): JSX.Element {
     const objectClass = this.objectClass;
     const info = objectClass.attributes[attribute];
-    if (info.defaultValue != null) {
+    if (options.defaultValue == null) {
       options.defaultValue = info.defaultValue;
     }
     return this.row(


### PR DESCRIPTION
Correct behavior should be:

<img src="https://user-images.githubusercontent.com/1595237/45934565-a28b5b00-bf54-11e8-9241-9e97d24c9436.png" width="250px" />

The regression:

<img src="https://user-images.githubusercontent.com/1595237/45934592-dd8d8e80-bf54-11e8-922d-afcc09ee842a.png" width="250px" />


The regression was likely introduced in PR #50 when I revised the code for mappingEditor.