### PR TITLE
Fix regression on condition by number

### DIFF
--- a/src/core/prototypes/scales/index.ts
+++ b/src/core/prototypes/scales/index.ts
@@ -42,6 +42,15 @@ const inferScaleTypeRules: InferScaleTypeRule[] = [
   },
   {
     input: {
+      type: [DataType.Number, DataType.Date],
+      kind: [DataKind.Numerical, DataKind.Temporal]
+    },
+    output: AttributeType.Boolean,
+    scale: "scale.linear<number,boolean>",
+    priority: 1
+  },
+  {
+    input: {
       type: DataType.String,
       kind: [DataKind.Categorical, DataKind.Ordinal]
     },


### PR DESCRIPTION
The number => boolean scale was forgotten in the scale inference rules.