### PR TITLE
Support multiple glyphs

### DIFF
--- a/sass/components/canvas/canvas.scss
+++ b/sass/components/canvas/canvas.scss
@@ -7,12 +7,32 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+
+  .glyph-tabs {
+    display: inline-block;
+    .el-item {
+      display: inline-block;
+      cursor: pointer;
+      height: 24px;
+      line-height: 24px;
+      padding: 0 4px;
+      border-radius: 0 0 2px 2px;
+      &.is-active {
+        background: $gray-220;
+      }
+      &:hover {
+        background: $gray-230;
+      }
+      margin-right: 1px;
+    }
+  }
 }
 
 .mark-editor-single-view {
   .mark-view-container {
     background: white;
     position: relative;
+
     .mark-view-container-notice {
       position: absolute;
       left: 0;
@@ -77,7 +97,15 @@
   line-height: 24px;
   height: 24px;
   font-size: 12px;
-  text-align: right;
+  display: flex;
+
+  &-left {
+    flex: 1 1;
+  }
+
+  &-right {
+    flex-shrink: 0;
+  }
 }
 
 .chart-editor-canvas-view {

--- a/sass/components/canvas/canvas.scss
+++ b/sass/components/canvas/canvas.scss
@@ -24,6 +24,7 @@
         background: $gray-230;
       }
       margin-right: 1px;
+      transition: background-color $transition-default;
     }
   }
 }

--- a/src/app/actions/actions.ts
+++ b/src/app/actions/actions.ts
@@ -165,6 +165,36 @@ export class SelectDataRow extends UIAction {
   }
 }
 
+// Glyph editing actions
+
+/** Add an empty glyph to the chart */
+export class AddGlyph extends Action {
+  constructor(public classID: string) {
+    super();
+  }
+
+  public digest() {
+    return {
+      name: "AddGlyph",
+      classID: this.classID
+    };
+  }
+}
+
+/** Remove a glyph from the chart */
+export class RemoveGlyph extends Action {
+  constructor(public glyph: Specification.Glyph) {
+    super();
+  }
+
+  public digest() {
+    return {
+      name: "RemoveGlyph",
+      glyph: objectDigest(this.glyph)
+    };
+  }
+}
+
 // Mark editing actions
 
 export class AddMarkToGlyph extends Action {
@@ -371,7 +401,7 @@ export class UpdateGlyphAttribute extends Action {
   }
 }
 
-export class AddPlotSegment extends Action {
+export class AddChartElement extends Action {
   constructor(
     public classID: string,
     public mappings: {
@@ -384,7 +414,7 @@ export class AddPlotSegment extends Action {
 
   public digest() {
     return {
-      name: "AddPlotSegment",
+      name: "AddChartElement",
       classID: this.classID,
       mappings: this.mappings,
       attribute: this.properties

--- a/src/app/stores/defaults.ts
+++ b/src/app/stores/defaults.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 import { Dataset, Specification, uniqueID } from "../../core";
 
+/** Create a default glyph */
 export function createDefaultGlyph(tableName: string) {
   return {
     _id: uniqueID(),
@@ -30,10 +31,101 @@ export function createDefaultGlyph(tableName: string) {
   } as Specification.Glyph;
 }
 
+/** Create a default plot segment */
+export function createDefaultPlotSegment(
+  table: Dataset.Table,
+  glyph: Specification.Glyph
+) {
+  return {
+    _id: uniqueID(),
+    classID: "plot-segment.cartesian",
+    glyph: glyph._id,
+    table: table.name,
+    filter: null,
+    mappings: {
+      x1: {
+        type: "parent",
+        parentAttribute: "x1"
+      } as Specification.ParentMapping,
+      y1: {
+        type: "parent",
+        parentAttribute: "y1"
+      } as Specification.ParentMapping,
+      x2: {
+        type: "parent",
+        parentAttribute: "x2"
+      } as Specification.ParentMapping,
+      y2: {
+        type: "parent",
+        parentAttribute: "y2"
+      } as Specification.ParentMapping
+    },
+    properties: {
+      name: "PlotSegment1",
+      visible: true,
+      marginX1: 0,
+      marginY1: 0,
+      marginX2: 0,
+      marginY2: 0,
+      sublayout: {
+        type: table.rows.length >= 100 ? "grid" : "dodge-x",
+        order: null,
+        ratioX: 0.1,
+        ratioY: 0.1,
+        align: {
+          x: "start",
+          y: "start"
+        },
+        grid: {
+          direction: "x",
+          xCount: null,
+          yCount: null
+        }
+      }
+    }
+  } as Specification.PlotSegment;
+}
+
+/** Create a default chart title */
+export function createDefaultTitle(dataset: Dataset.Dataset) {
+  return {
+    _id: uniqueID(),
+    classID: "mark.text",
+    properties: {
+      name: "Title",
+      visible: true,
+      alignment: { x: "middle", y: "top", xMargin: 0, yMargin: 30 },
+      rotation: 0
+    },
+    mappings: {
+      x: {
+        type: "parent",
+        parentAttribute: "cx"
+      } as Specification.ParentMapping,
+      y: {
+        type: "parent",
+        parentAttribute: "oy2"
+      } as Specification.ParentMapping,
+      text: {
+        type: "value",
+        value: dataset.name
+      } as Specification.ValueMapping,
+      fontSize: {
+        type: "value",
+        value: 24
+      } as Specification.ValueMapping,
+      color: {
+        type: "value",
+        value: { r: 0, g: 0, b: 0 }
+      } as Specification.ValueMapping
+    }
+  } as Specification.ChartElement;
+}
+
+/** Create a default chart */
 export function createDefaultChart(dataset: Dataset.Dataset) {
-  const tableName = dataset.tables[0].name;
-  const rows = dataset.tables[0].rows;
-  const glyph = createDefaultGlyph(tableName);
+  const table = dataset.tables[0];
+  const glyph = createDefaultGlyph(table.name);
   return {
     _id: uniqueID(),
     classID: "chart.rectangle",
@@ -47,86 +139,8 @@ export function createDefaultChart(dataset: Dataset.Dataset) {
     },
     glyphs: [glyph],
     elements: [
-      {
-        _id: uniqueID(),
-        classID: "plot-segment.cartesian",
-        glyph: glyph._id,
-        table: tableName,
-        filter: null,
-        mappings: {
-          x1: {
-            type: "parent",
-            parentAttribute: "x1"
-          } as Specification.ParentMapping,
-          y1: {
-            type: "parent",
-            parentAttribute: "y1"
-          } as Specification.ParentMapping,
-          x2: {
-            type: "parent",
-            parentAttribute: "x2"
-          } as Specification.ParentMapping,
-          y2: {
-            type: "parent",
-            parentAttribute: "y2"
-          } as Specification.ParentMapping
-        },
-        properties: {
-          name: "PlotSegment1",
-          visible: true,
-          marginX1: 0,
-          marginY1: 0,
-          marginX2: 0,
-          marginY2: 0,
-          sublayout: {
-            type: rows.length >= 100 ? "grid" : "dodge-x",
-            order: null,
-            ratioX: 0.1,
-            ratioY: 0.1,
-            align: {
-              x: "start",
-              y: "start"
-            },
-            grid: {
-              direction: "x",
-              xCount: null,
-              yCount: null
-            }
-          }
-        }
-      } as Specification.PlotSegment,
-      {
-        _id: uniqueID(),
-        classID: "mark.text",
-        properties: {
-          name: "Title",
-          visible: true,
-          alignment: { x: "middle", y: "top", xMargin: 0, yMargin: 30 },
-          rotation: 0
-        },
-        mappings: {
-          x: {
-            type: "parent",
-            parentAttribute: "cx"
-          } as Specification.ParentMapping,
-          y: {
-            type: "parent",
-            parentAttribute: "oy2"
-          } as Specification.ParentMapping,
-          text: {
-            type: "value",
-            value: dataset.name
-          } as Specification.ValueMapping,
-          fontSize: {
-            type: "value",
-            value: 24
-          } as Specification.ValueMapping,
-          color: {
-            type: "value",
-            value: { r: 0, g: 0, b: 0 }
-          } as Specification.ValueMapping
-        }
-      } as Specification.ChartElement
+      createDefaultPlotSegment(table, glyph),
+      createDefaultTitle(dataset)
     ],
     scales: [],
     constraints: [],

--- a/src/app/stores/defaults.ts
+++ b/src/app/stores/defaults.ts
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+import { Dataset, Specification, uniqueID } from "../../core";
+
+export function createDefaultGlyph(tableName: string) {
+  return {
+    _id: uniqueID(),
+    classID: "glyph.rectangle",
+    properties: { name: "Glyph" },
+    table: tableName,
+    marks: [
+      {
+        _id: uniqueID(),
+        classID: "mark.anchor",
+        properties: { name: "Anchor" },
+        mappings: {
+          x: {
+            type: "parent",
+            parentAttribute: "icx"
+          } as Specification.ParentMapping,
+          y: {
+            type: "parent",
+            parentAttribute: "icy"
+          } as Specification.ParentMapping
+        }
+      }
+    ],
+    mappings: {},
+    constraints: []
+  } as Specification.Glyph;
+}
+
+export function createDefaultChart(dataset: Dataset.Dataset) {
+  const tableName = dataset.tables[0].name;
+  const rows = dataset.tables[0].rows;
+  const glyph = createDefaultGlyph(tableName);
+  return {
+    _id: uniqueID(),
+    classID: "chart.rectangle",
+    properties: {
+      name: "Chart",
+      backgroundColor: null,
+      backgroundOpacity: 1
+    },
+    mappings: {
+      marginTop: { type: "value", value: 80 } as Specification.ValueMapping
+    },
+    glyphs: [glyph],
+    elements: [
+      {
+        _id: uniqueID(),
+        classID: "plot-segment.cartesian",
+        glyph: glyph._id,
+        table: tableName,
+        filter: null,
+        mappings: {
+          x1: {
+            type: "parent",
+            parentAttribute: "x1"
+          } as Specification.ParentMapping,
+          y1: {
+            type: "parent",
+            parentAttribute: "y1"
+          } as Specification.ParentMapping,
+          x2: {
+            type: "parent",
+            parentAttribute: "x2"
+          } as Specification.ParentMapping,
+          y2: {
+            type: "parent",
+            parentAttribute: "y2"
+          } as Specification.ParentMapping
+        },
+        properties: {
+          name: "PlotSegment1",
+          visible: true,
+          marginX1: 0,
+          marginY1: 0,
+          marginX2: 0,
+          marginY2: 0,
+          sublayout: {
+            type: rows.length >= 100 ? "grid" : "dodge-x",
+            order: null,
+            ratioX: 0.1,
+            ratioY: 0.1,
+            align: {
+              x: "start",
+              y: "start"
+            },
+            grid: {
+              direction: "x",
+              xCount: null,
+              yCount: null
+            }
+          }
+        }
+      } as Specification.PlotSegment,
+      {
+        _id: uniqueID(),
+        classID: "mark.text",
+        properties: {
+          name: "Title",
+          visible: true,
+          alignment: { x: "middle", y: "top", xMargin: 0, yMargin: 30 },
+          rotation: 0
+        },
+        mappings: {
+          x: {
+            type: "parent",
+            parentAttribute: "cx"
+          } as Specification.ParentMapping,
+          y: {
+            type: "parent",
+            parentAttribute: "oy2"
+          } as Specification.ParentMapping,
+          text: {
+            type: "value",
+            value: dataset.name
+          } as Specification.ValueMapping,
+          fontSize: {
+            type: "value",
+            value: 24
+          } as Specification.ValueMapping,
+          color: {
+            type: "value",
+            value: { r: 0, g: 0, b: 0 }
+          } as Specification.ValueMapping
+        }
+      } as Specification.ChartElement
+    ],
+    scales: [],
+    constraints: [],
+    resources: []
+  } as Specification.Chart;
+}

--- a/src/app/views/canvas/chart_editor.tsx
+++ b/src/app/views/canvas/chart_editor.tsx
@@ -364,7 +364,7 @@ export class ChartEditorView
                 attributes[key] = opt[key];
               }
             }
-            new Actions.AddPlotSegment(classID, mappings, attributes).dispatch(
+            new Actions.AddChartElement(classID, mappings, attributes).dispatch(
               this.props.store.dispatcher
             );
           }}
@@ -398,7 +398,7 @@ export class ChartEditorView
           {
             mode = "vline";
             onCreate = x => {
-              new Actions.AddPlotSegment(
+              new Actions.AddChartElement(
                 "guide.guide",
                 { value: x },
                 { axis: "x" }
@@ -410,7 +410,7 @@ export class ChartEditorView
           {
             mode = "hline";
             onCreate = y => {
-              new Actions.AddPlotSegment(
+              new Actions.AddChartElement(
                 "guide.guide",
                 { value: y },
                 { axis: "y" }
@@ -422,7 +422,7 @@ export class ChartEditorView
           {
             mode = "line";
             onCreate = (x1, y1, x2, y2) => {
-              new Actions.AddPlotSegment(
+              new Actions.AddChartElement(
                 "guide.guide-coordinator",
                 { x1, y1, x2, y2 },
                 { axis: "x", count: 4 }
@@ -434,7 +434,7 @@ export class ChartEditorView
           {
             mode = "line";
             onCreate = (x1, y1, x2, y2) => {
-              new Actions.AddPlotSegment(
+              new Actions.AddChartElement(
                 "guide.guide-coordinator",
                 { x1, y1, x2, y2 },
                 { axis: "y", count: 4 }
@@ -1104,59 +1104,62 @@ export class ChartEditorView
           {this.renderControls()}
         </div>
         <div className="canvas-controls">
-          <Button
-            icon="general/zoom-in"
-            onClick={() => {
-              const { scale, centerX, centerY } = this.state.zoom;
-              const fixPoint = Geometry.unapplyZoom(this.state.zoom, {
-                x: this.state.viewWidth / 2,
-                y: this.state.viewHeight / 2
-              });
-              let newScale = scale * 1.1;
-              newScale = Math.min(20, Math.max(0.05, newScale));
-              this.setState({
-                zoom: {
-                  centerX: centerX + (scale - newScale) * fixPoint.x,
-                  centerY: centerY + (scale - newScale) * fixPoint.y,
-                  scale: newScale
+          <div className="canvas-controls-left" />
+          <div className="canvas-controls-right">
+            <Button
+              icon="general/zoom-in"
+              onClick={() => {
+                const { scale, centerX, centerY } = this.state.zoom;
+                const fixPoint = Geometry.unapplyZoom(this.state.zoom, {
+                  x: this.state.viewWidth / 2,
+                  y: this.state.viewHeight / 2
+                });
+                let newScale = scale * 1.1;
+                newScale = Math.min(20, Math.max(0.05, newScale));
+                this.setState({
+                  zoom: {
+                    centerX: centerX + (scale - newScale) * fixPoint.x,
+                    centerY: centerY + (scale - newScale) * fixPoint.y,
+                    scale: newScale
+                  }
+                });
+              }}
+            />
+            <Button
+              icon="general/zoom-out"
+              onClick={() => {
+                const { scale, centerX, centerY } = this.state.zoom;
+                const fixPoint = Geometry.unapplyZoom(this.state.zoom, {
+                  x: this.state.viewWidth / 2,
+                  y: this.state.viewHeight / 2
+                });
+                let newScale = scale / 1.1;
+                newScale = Math.min(20, Math.max(0.05, newScale));
+                this.setState({
+                  zoom: {
+                    centerX: centerX + (scale - newScale) * fixPoint.x,
+                    centerY: centerY + (scale - newScale) * fixPoint.y,
+                    scale: newScale
+                  }
+                });
+              }}
+            />
+            <Button
+              icon="general/zoom-auto"
+              onClick={() => {
+                const newZoom = this.getFitViewZoom(
+                  this.state.viewWidth,
+                  this.state.viewHeight
+                );
+                if (!newZoom) {
+                  return;
                 }
-              });
-            }}
-          />
-          <Button
-            icon="general/zoom-out"
-            onClick={() => {
-              const { scale, centerX, centerY } = this.state.zoom;
-              const fixPoint = Geometry.unapplyZoom(this.state.zoom, {
-                x: this.state.viewWidth / 2,
-                y: this.state.viewHeight / 2
-              });
-              let newScale = scale / 1.1;
-              newScale = Math.min(20, Math.max(0.05, newScale));
-              this.setState({
-                zoom: {
-                  centerX: centerX + (scale - newScale) * fixPoint.x,
-                  centerY: centerY + (scale - newScale) * fixPoint.y,
-                  scale: newScale
-                }
-              });
-            }}
-          />
-          <Button
-            icon="general/zoom-auto"
-            onClick={() => {
-              const newZoom = this.getFitViewZoom(
-                this.state.viewWidth,
-                this.state.viewHeight
-              );
-              if (!newZoom) {
-                return;
-              }
-              this.setState({
-                zoom: newZoom
-              });
-            }}
-          />
+                this.setState({
+                  zoom: newZoom
+                });
+              }}
+            />
+          </div>
         </div>
         {this.state.isSolving ? (
           <div className="solving-hint">

--- a/src/app/views/canvas/mark_editor.tsx
+++ b/src/app/views/canvas/mark_editor.tsx
@@ -196,13 +196,13 @@ export class MarkEditorView extends ContextedComponent<
             <Button
               icon="general/zoom-in"
               onClick={() => {
-                this.refSingleMarkView.doZoomIn();
+                this.refSingleMarkView.doZoom(1.1);
               }}
             />
             <Button
               icon="general/zoom-out"
               onClick={() => {
-                this.refSingleMarkView.doZoomOut();
+                this.refSingleMarkView.doZoom(1 / 1.1);
               }}
             />
             <Button
@@ -272,30 +272,13 @@ export class SingleMarkView
     };
   }
 
-  public doZoomIn() {
+  public doZoom(factor: number) {
     const { scale, centerX, centerY } = this.state.zoom;
     const fixPoint = Geometry.unapplyZoom(this.state.zoom, {
       x: this.props.width / 2,
       y: this.props.height / 2
     });
-    let newScale = scale * 1.1;
-    newScale = Math.min(20, Math.max(0.05, newScale));
-    this.setState({
-      zoom: {
-        centerX: centerX + (scale - newScale) * fixPoint.x,
-        centerY: centerY + (scale - newScale) * fixPoint.y,
-        scale: newScale
-      }
-    });
-  }
-
-  public doZoomOut() {
-    const { scale, centerX, centerY } = this.state.zoom;
-    const fixPoint = Geometry.unapplyZoom(this.state.zoom, {
-      x: this.props.width / 2,
-      y: this.props.height / 2
-    });
-    let newScale = scale / 1.1;
+    let newScale = scale * factor;
     newScale = Math.min(20, Math.max(0.05, newScale));
     this.setState({
       zoom: {

--- a/src/core/prototypes/state.ts
+++ b/src/core/prototypes/state.ts
@@ -334,33 +334,32 @@ export class ChartStateManager {
   public addGlyph(classID: string, table: string): Specification.Glyph {
     const newGlyph: Specification.Glyph = {
       _id: uniqueID(),
-      table,
       classID,
+      properties: { name: this.findUnusedName("Glyph") },
+      table,
       marks: [
         {
           _id: uniqueID(),
           classID: "mark.anchor",
+          properties: { name: "Anchor" },
           mappings: {
             x: {
               type: "parent",
-              parentAttribute: "cx"
+              parentAttribute: "icx"
             } as Specification.ParentMapping,
             y: {
               type: "parent",
-              parentAttribute: "cy"
+              parentAttribute: "icy"
             } as Specification.ParentMapping
-          },
-          properties: { name: "Anchor" }
+          }
         }
       ],
-      properties: {
-        name: this.findUnusedName("Glyph")
-      },
       mappings: {},
       constraints: []
     };
     this.idIndex.set(newGlyph._id, [newGlyph, null]);
     this.idIndex.set(newGlyph.marks[0]._id, [newGlyph.marks[0], null]);
+    this.chart.glyphs.push(newGlyph);
     return newGlyph;
   }
   /** Remove a glyph */


### PR DESCRIPTION
With multiple glyphs, we can create charts like the one below:

<img src="https://user-images.githubusercontent.com/1595237/46274044-ccbcba00-c50c-11e8-990e-1398c528a9e1.png" width="600px" />

This PR adds a tab view under the glyph editor:

![image](https://user-images.githubusercontent.com/1595237/46274070-e6f69800-c50c-11e8-9cbb-222c06a6f7f2.png)