### PR TITLE
update http-server to 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "dts-bundle": "^0.7.3",
     "file-loader": "^2.0.0",
     "fs-extra": "^7.0.1",
-    "http-server": "^0.11.1",
+    "http-server": "^0.12.0",
     "husky": "^1.1.3",
     "js-yaml": "^3.13.1",
     "license-check-and-add": "^2.3.6",


### PR DESCRIPTION
This fixes the "too many redirects" error on Windows.