### PR TITLE
Add monthnumber for date fields

### DIFF
--- a/src/app/views/dataset/common.ts
+++ b/src/app/views/dataset/common.ts
@@ -101,6 +101,15 @@ export const type2DerivedColumns: {
       }
     },
     {
+      name: "monthnumber",
+      type: Dataset.DataType.String,
+      function: "date.monthnumber",
+      metadata: {
+        kind: Dataset.DataKind.Categorical,
+        orderMode: "alphabetically"
+      }
+    },
+    {
       name: "day",
       type: Dataset.DataType.String,
       function: "date.day",

--- a/src/core/expression/intrinsics.ts
+++ b/src/core/expression/intrinsics.ts
@@ -234,6 +234,7 @@ functions.date = {
 
   year: makeArrayCapable1(utcFormat("%Y")), // year with century as a decimal number.
   month: makeArrayCapable1(utcFormat("%b")), // month as a string "Jan" - "Dec".
+  monthnumber: makeArrayCapable1(utcFormat("%m")), // zero-padded number of the month as a decimal number [01,12].
   day: makeArrayCapable1(utcFormat("%d")), // zero-padded day of the month as a decimal number [01,31].
   weekOfYear: makeArrayCapable1(utcFormat("%U")), // Sunday-based week of the year as a decimal number [00,53].
   dayOfYear: makeArrayCapable1(utcFormat("%j")), // day of the year as a decimal number [001,366].


### PR DESCRIPTION
I needed to show the month number for date fields, but there was no option for it, so I added the few lines of code that allow it.

Later I have found that visuals using date fields do not work well in PowerBI (at least for me), so maybe this is not useful in the end for PowerBI users, buy it still may be of use for the rest of Charticulator users.