### PR TITLE
Hold current axis scale range and aggregation function

### DIFF
--- a/src/app/stores/app_store.ts
+++ b/src/app/stores/app_store.ts
@@ -1083,7 +1083,11 @@ export class AppStore extends BaseStore {
 
     let dataBinding: Specification.Types.AxisDataBinding = {
       type: options.type || type,
-      expression: groupExpression,
+      // Don't change current expression (use current expression), if user appends data expression ()
+      expression:
+        appendToProperty === "dataExpressions"
+          ? ((object.properties[options.property] as any).expression as string)
+          : groupExpression,
       valueType,
       gapRatio: 0.1,
       visible: true,
@@ -1138,6 +1142,10 @@ export class AppStore extends BaseStore {
       }
     }
     let values: ValueType[] = [];
+    if (appendToProperty == "dataExpressions") {
+      // save current range of scale if user adds data
+      values = values.concat(dataBinding.domainMax, dataBinding.domainMin);
+    }
     for (const expr of expressions) {
       const r = this.chartManager.getGroupedExpressionVector(
         dataExpression.table.name,

--- a/src/app/template/index.ts
+++ b/src/app/template/index.ts
@@ -397,7 +397,10 @@ export class ChartTemplateBuilder {
 
       Object.keys(state.attributes).forEach(attribute => {
         // Only support numbers for now
-        if (cls.attributes[attribute].type === "number") {
+        if (
+          cls.attributes[attribute] &&
+          cls.attributes[attribute].type === "number"
+        ) {
           totals[attribute] = totals[attribute] || 0;
           totals[attribute] += state.attributes[attribute] || 0;
           counts[_id] = (counts[_id] || 0) + 1;


### PR DESCRIPTION
Hold current axis scale range and aggregation function on appending a data expression.

Improves issue described in https://github.com/microsoft/charticulator/issues/302#issuecomment-671946110