### PR TITLE
Add Slot examples for template export

### DIFF
--- a/src/app/views/file_view/export_view.tsx
+++ b/src/app/views/file_view/export_view.tsx
@@ -350,7 +350,7 @@ export class ExportTemplateView extends ContextedComponent<
           .map((column) => (
             <div key={column.name}>
               {this.renderInput(
-                column.name,
+                column.name + " name",
                 "string",
                 column.displayName,
                 null,

--- a/src/app/views/file_view/export_view.tsx
+++ b/src/app/views/file_view/export_view.tsx
@@ -4,6 +4,7 @@
 import * as React from "react";
 import { CurrentChartView } from ".";
 import { deepClone, Specification, Prototypes } from "../../../core";
+import { ensureColumnsHaveExamples } from "../../../core/dataset/examples";
 import { findObjectById } from "../../../core/prototypes";
 import { strings } from "../../../strings";
 import { Actions } from "../../actions";
@@ -214,6 +215,7 @@ export class ExportTemplateView extends ContextedComponent<
   public state = this.getDefaultState(this.props.exportKind);
 
   public getDefaultState(kind: string): ExportTemplateViewState {
+    this.store.dataset.tables.forEach((t) => ensureColumnsHaveExamples(t));
     const template = deepClone(this.store.buildChartTemplate());
     const target = this.store.createExportTemplateTarget(kind, template);
     const targetProperties: { [name: string]: string } = {};
@@ -353,14 +355,31 @@ export class ExportTemplateView extends ContextedComponent<
                 column.displayName,
                 null,
                 (value) => {
-                  const dataTable = this.store.dataset.tables.find(
-                    (t) => t.name === table.name
+                  const originalColumn = this.getOriginalColumn(
+                    table.name,
+                    column.name
                   );
-                  const dataColumn = dataTable.columns.find(
-                    (c) => c.name === column.name
+                  [originalColumn, column].forEach(
+                    (c) => (c.displayName = value)
                   );
-                  dataColumn.displayName = value;
-                  column.displayName = value;
+                  this.setState({
+                    template: this.state.template,
+                  });
+                }
+              )}
+              {this.renderInput(
+                column.name + " examples",
+                "string",
+                column.metadata.examples,
+                null,
+                (value) => {
+                  const originalColumn = this.getOriginalColumn(
+                    table.name,
+                    column.name
+                  );
+                  [originalColumn, column].forEach(
+                    (c) => (c.metadata.examples = value)
+                  );
                   this.setState({
                     template: this.state.template,
                   });
@@ -370,6 +389,14 @@ export class ExportTemplateView extends ContextedComponent<
           ))}
       </div>
     ));
+  }
+
+  private getOriginalColumn(tableName: string, columnName: string) {
+    const dataTable = this.store.dataset.tables.find(
+      (t) => t.name === tableName
+    );
+    const dataColumn = dataTable.columns.find((c) => c.name === columnName);
+    return dataColumn;
   }
 
   public renderInferences() {

--- a/src/app/views/file_view/import_view.tsx
+++ b/src/app/views/file_view/import_view.tsx
@@ -120,6 +120,9 @@ export class FileViewImport extends ContextedComponent<
                             Required data type
                           </th>
                           <th className="charticulator__file-view-mapping_row_item">
+                            Examples
+                          </th>
+                          <th className="charticulator__file-view-mapping_row_item">
                             Dataset column
                           </th>
                         </tr>
@@ -158,6 +161,9 @@ export class FileViewImport extends ContextedComponent<
                                 </td>
                                 <td className="charticulator__file-view-mapping_row_item">
                                   {strings.typeDisplayNames[column.type]}
+                                </td>
+                                <td className="charticulator__file-view-mapping_row_item">
+                                  {column.metadata.examples}
                                 </td>
                                 <td className="charticulator__file-view-mapping_row_item">
                                   <Select

--- a/src/app/views/file_view/index.tsx
+++ b/src/app/views/file_view/index.tsx
@@ -148,11 +148,12 @@ export class FileView extends React.Component<FileViewProps, FileViewState> {
           <div className="el-button-back" onClick={() => this.props.onClose()}>
             <SVGImageIcon url={R.getSVGIcon("toolbar/back")} />
           </div>
-          {tabOrder.map((t) =>
+          {tabOrder.map((t, i) =>
             t === null ? (
-              <div className="el-sep" />
+              <div key={i} className="el-sep" />
             ) : (
               <div
+                key={i}
                 className={classNames("el-tab", [
                   "active",
                   this.state.currentTab == t,

--- a/src/core/dataset/dataset.ts
+++ b/src/core/dataset/dataset.ts
@@ -25,6 +25,7 @@ export interface ColumnMetadata {
   format?: string;
   rawColumnName?: string;
   isRaw?: boolean;
+  examples?: string;
 }
 
 export interface Column {

--- a/src/core/dataset/examples.ts
+++ b/src/core/dataset/examples.ts
@@ -8,7 +8,6 @@ const delim = ",";
 
 export function ensureColumnsHaveExamples(table: Table) {
   table.columns.forEach((c) => {
-    console.log("ensureColumnsHaveExamples");
     if (!c.metadata.examples) {
       let examples: string[] = [];
       if (c.type === DataType.Boolean) {

--- a/src/core/dataset/examples.ts
+++ b/src/core/dataset/examples.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { Column, Table } from "./dataset";
+
+export function ensureColumnsHaveExamples(t: Table) {
+  console.log("table name", t.name);
+  t.columns.forEach((c) => {
+    console.log(`column ${c.name}`, c.metadata);
+    if (!c.metadata.examples) {
+      populateExamples(t, c);
+    }
+  });
+}
+
+function populateExamples(t: Table, c: Column) {
+  const examples: string[] = [];
+  t.rows.forEach((r) => {
+    examples.push(r[c.name].toString());
+  });
+  c.metadata.examples = examples.join("");
+}


### PR DESCRIPTION
When exporting a template, slots now have "name" and "examples" input fields:
![image](https://user-images.githubusercontent.com/11507384/101823936-5c445700-3ae0-11eb-94e0-990f42316e91.png)
 