### PR TITLE
Delete .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-    - "10"
-before_script:
-    - cp config.template.yml config.yml


### PR DESCRIPTION
Travis has not been functional, moving to Azure DevOps instead.