### PR TITLE
Swapped evaluation of decimal & remove for locale formatting

### DIFF
--- a/src/app/application.tsx
+++ b/src/app/application.tsx
@@ -110,16 +110,16 @@ export class Application {
         delimiter: DelimiterSymbol,
         group: parseSafe(GroupSymbol, defaultDigitsGroup),
         numberFormat: {
-          decimal: NumberFormatRemove === "." ? "." : ",",
-          remove: NumberFormatRemove === "." ? "," : ".",
+          decimal: NumberFormatRemove === "," ? "." : ",",
+          remove: NumberFormatRemove === "," ? "," : ".",
         },
       });
 
       setFormatOptions({
         currency: parseSafe(CurrencySymbol, defaultCurrency),
         grouping: parseSafe(GroupSymbol, defaultDigitsGroup),
-        decimal: NumberFormatRemove === "." ? "." : ",",
-        thousands: NumberFormatRemove === "." ? "," : ".",
+        decimal: NumberFormatRemove === "," ? "." : ",",
+        thousands: NumberFormatRemove === "," ? "," : ".",
       });
     } catch (ex) {
       console.warn("Loadin localization settings failed");

--- a/src/container/chart_template.ts
+++ b/src/container/chart_template.ts
@@ -22,7 +22,7 @@ import {
 import { CompiledGroupBy } from "../core/prototypes/group_by";
 import { OrderMode } from "../core/specification/types";
 import { DataAxisExpression } from "../core/prototypes/marks/data_axis.attrs";
-import { AttributeList } from "../core/specification";
+import { AttributeList, ScaleMapping } from "../core/specification";
 
 export interface TemplateInstance {
   chart: Specification.Chart;
@@ -129,6 +129,16 @@ export class ChartTemplate {
     for (const item of forEachObject(chart)) {
       // Replace table with assigned table
       if (item.kind == "chart-element") {
+        // legend with column names
+        if (Prototypes.isType(item.chartElement.classID, "legend.custom")) {
+          const scaleMapping = item.chartElement.mappings
+            .mappingOptions as ScaleMapping;
+          scaleMapping.expression = this.transformExpression(
+            scaleMapping.expression,
+            scaleMapping.table
+          );
+        }
+
         // PlotSegment
         if (Prototypes.isType(item.chartElement.classID, "plot-segment")) {
           const plotSegment = item.chartElement as Specification.PlotSegment;


### PR DESCRIPTION
Proposed fix for #415 

Decimal numbers now resolve correctly on import:

![image](https://user-images.githubusercontent.com/10572054/107888531-a975f680-6f71-11eb-8585-2d9b05127e0a.png)

----

re: testing, I'm not 100% sure this will work for all cases, but the current expression evaluates incorrectly on my environment, as the `numberFormatRemove` object is not present in local storage, so is evaluated as follows on my machine:

![image](https://user-images.githubusercontent.com/10572054/107888566-f3f77300-6f71-11eb-9255-39b0322b13bd.png)

I'm not able to verify how the Options component resolves my locale in the UI, as clicking it this currently kills the app (may already be a known issue; diagnostic information for that as follows):

```
TypeError 
 react_1.useState is not a function or its return value is not iterable 
 TypeError: react_1.useState is not a function or its return value is not iterable
    at Object.useLocalStorage (webpack://Charticulator/./dist/scripts/app/utils/hooks.js?:8:53)
    at FileViewOptionsView (webpack://Charticulator/./dist/scripts/app/views/file_view/options_view.js?:14:67)
    at mountIndeterminateComponent (webpack://Charticulator/./node_modules/react-dom/cjs/react-dom.development.js?:14563:13)
    at beginWork (webpack://Charticulator/./node_modules/react-dom/cjs/react-dom.development.js?:15063:16)
    at performUnitOfWork (webpack://Charticulator/./node_modules/react-dom/cjs/react-dom.development.js?:17820:12)
    at workLoop (webpack://Charticulator/./node_modules/react-dom/cjs/react-dom.development.js?:17860:24)
    at renderRoot (webpack://Charticulator/./node_modules/react-dom/cjs/react-dom.development.js?:17946:7)
    at performWorkOnRoot (webpack://Charticulator/./node_modules/react-dom/cjs/react-dom.development.js?:18837:7)
    at performWork (webpack://Charticulator/./node_modules/react-dom/cjs/react-dom.development.js?:18749:7)
    at performSyncWork (webpack://Charticulator/./node_modules/react-dom/cjs/react-dom.development.js?:18723:3) 
 
    in FileViewOptionsView (created by FileViewOptions)
    in FileViewOptions (created by FileView)
    in ErrorBoundary (created by FileView)
    in div (created by FileView)
    in FileView
    in div (created by ModalView)
    in div (created by ModalView)
    in ModalView
    in div (created by PopupContainer)
    in PopupContainer (created by MainView)
    in div (created by MainView)
    in MainView
```