### PR TITLE
Quantile Expressions and Helpers

### DIFF
--- a/src/core/expression/helpers.ts
+++ b/src/core/expression/helpers.ts
@@ -79,6 +79,13 @@ export const aggregationFunctions: AggregationFunctionDescription[] = [
   { name: "first", displayName: "First" },
   { name: "last", displayName: "Last" },
   { name: "count", displayName: "Count" },
+  { name: "quartile1", displayName: "1st Quartile", inputTypes: ["number"] },
+  { name: "quartile3", displayName: "3rd Quartile", inputTypes: ["number"] },
+  {
+    name: "iqr",
+    displayName: "Inter Quartile Range (IQR)",
+    inputTypes: ["number"],
+  },
 ];
 
 export function getCompatibleAggregationFunctions(inputType: string) {

--- a/src/core/expression/intrinsics.ts
+++ b/src/core/expression/intrinsics.ts
@@ -130,6 +130,21 @@ function stat_foreach(f: (x: number) => void, list: (number | number[])[]) {
     }
   }
 }
+function quantile(q: number, list: (number | number[])[]) {
+  const values: number[] = [];
+  stat_foreach((x) => {
+    values.push(x);
+  }, list);
+  values.sort((a, b) => a - b);
+  const pos = (values.length - 1) * q,
+    base = Math.floor(pos),
+    rest = pos - base;
+  return (
+    (values[base + 1] &&
+      values[base] + rest * (values[base + 1] - values[base])) ||
+    values[base]
+  );
+}
 functions.min = (...list: (number | number[])[]) => {
   let r: number = null;
   stat_foreach((x) => {
@@ -211,6 +226,12 @@ functions.avg = (...list: (number | number[])[]) => {
 };
 functions.mean = functions.avg;
 functions.average = functions.avg;
+functions.quantile = (q: number, list: (number | number[])[]) =>
+  quantile(q, list);
+functions.quartile1 = (...list: (number | number[])[]) => quantile(0.25, list);
+functions.quartile3 = (...list: (number | number[])[]) => quantile(0.75, list);
+functions.iqr = (...list: (number | number[])[]) =>
+  quantile(0.75, list) - quantile(0.25, list);
 
 // General operators
 operators["+"] = makeArrayCapable2((a: any, b: any) => a + b);


### PR DESCRIPTION
Added a `quantile` function, which accepts a percentage value as input, plus the field array, which can be used to calculate quantiles wherever expressions are used, e.g. (for a box plot data axis):

![image](https://user-images.githubusercontent.com/10572054/116325368-17faee80-a816-11eb-8fa9-f8d467654b7b.png)

Additionally, I've added the following functions as shortcuts (plus helpers):

- `quartile1` (1st Quartile)
- `quartile3` (3rd Quartile)
- `iqr` (Inter-Quartile Range)

![image](https://user-images.githubusercontent.com/10572054/116325416-352fbd00-a816-11eb-8251-c9686ee01808.png)

![image](https://user-images.githubusercontent.com/10572054/116325517-74f6a480-a816-11eb-9fcd-98c1b982b4cb.png)

Resolves #499
