### PR TITLE
Change default color from grey to blue

### DIFF
--- a/src/core/prototypes/marks/rect.ts
+++ b/src/core/prototypes/marks/rect.ts
@@ -53,7 +53,7 @@ export class RectElementClass extends EmphasizableMarkClass<
   };
 
   public static defaultMappingValues: Partial<RectElementAttributes> = {
-    fill: { r: 33, g: 113, b: 181 },
+    fill: { r: 17, g: 141, b: 255 },
     strokeWidth: 1,
     opacity: 1,
     visible: true,

--- a/src/core/prototypes/marks/rect.ts
+++ b/src/core/prototypes/marks/rect.ts
@@ -53,7 +53,7 @@ export class RectElementClass extends EmphasizableMarkClass<
   };
 
   public static defaultMappingValues: Partial<RectElementAttributes> = {
-    fill: { r: 217, g: 217, b: 217 },
+    fill: { r: 33, g: 113, b: 181 },
     strokeWidth: 1,
     opacity: 1,
     visible: true,

--- a/src/core/prototypes/marks/symbol.ts
+++ b/src/core/prototypes/marks/symbol.ts
@@ -52,7 +52,7 @@ export class SymbolElementClass extends EmphasizableMarkClass<
   };
 
   public static defaultMappingValues: Partial<SymbolElementAttributes> = {
-    fill: { r: 33, g: 113, b: 181 },
+    fill: { r: 17, g: 141, b: 255 },
     strokeWidth: 1,
     opacity: 1,
     size: 60,

--- a/src/core/prototypes/marks/symbol.ts
+++ b/src/core/prototypes/marks/symbol.ts
@@ -52,7 +52,7 @@ export class SymbolElementClass extends EmphasizableMarkClass<
   };
 
   public static defaultMappingValues: Partial<SymbolElementAttributes> = {
-    fill: { r: 217, g: 217, b: 217 },
+    fill: { r: 33, g: 113, b: 181 },
     strokeWidth: 1,
     opacity: 1,
     size: 60,


### PR DESCRIPTION
Set default color from grey to blue for rect and symbol objects

![image](https://user-images.githubusercontent.com/10897951/119983471-e027c800-bfc8-11eb-896f-0b416d658159.png)