### PR TITLE
Fix issue when guide mapping value not set on creating guide

### DIFF
--- a/src/app/views/canvas/mark_editor.tsx
+++ b/src/app/views/canvas/mark_editor.tsx
@@ -39,7 +39,11 @@ import {
   GuideProperties,
 } from "../../../core/prototypes/guides";
 import { strings } from "../../../strings";
-import { PlotSegment } from "../../../core/specification";
+import {
+  MappingType,
+  PlotSegment,
+  ValueMapping,
+} from "../../../core/specification";
 import { SnappingGuidesVisualTypes } from "../../../core/prototypes";
 
 export interface MarkEditorViewProps {
@@ -1437,7 +1441,15 @@ export class SingleMarkView
             this.props.glyph,
             "guide.guide",
             { x: 0, y: 0 },
-            { value },
+            {
+              value: [
+                value[0],
+                {
+                  type: MappingType.value,
+                  value: value[0],
+                } as ValueMapping,
+              ],
+            },
             guideProperties
           )
         );


### PR DESCRIPTION
To fix https://github.com/microsoft/charticulator/issues/586 and https://github.com/microsoft/charticulator/issues/201