### PR TITLE
Don't render canvas toolbar outside canvas viewport

### DIFF
--- a/src/app/views/canvas/chart_editor.tsx
+++ b/src/app/views/canvas/chart_editor.tsx
@@ -977,6 +977,9 @@ export class ChartEditorView
                   x: controls.anchor.x,
                   y: -controls.anchor.y,
                 });
+                if (pt.x < 0 || pt.y < 0) {
+                  return null;
+                }
                 return (
                   <>
                     <div


### PR DESCRIPTION
Issue:
![image](https://user-images.githubusercontent.com/10897951/129024251-1cb2bbd5-327d-46dc-af77-78bdae1c3d6f.png)
Toolbar renders when plotsegment coner is outside of viewport