### PR TITLE
PoC:  Change margin properties to attributes to map data

### DIFF
--- a/src/core/prototypes/marks/text.attrs.ts
+++ b/src/core/prototypes/marks/text.attrs.ts
@@ -28,6 +28,20 @@ export const textAttributes: AttributeDescriptions = {
     defaultRange: [0, 24],
     defaultValue: defaultFontSize,
   },
+  xMargin: {
+    name: "xMargin",
+    type: AttributeType.Number,
+    solverExclude: true,
+    defaultRange: [-100, 100],
+    defaultValue: 0,
+  },
+  yMargin: {
+    name: "yMargin",
+    type: AttributeType.Number,
+    solverExclude: true,
+    defaultRange: [-1000, 1000],
+    defaultValue: 0,
+  },
   color: {
     name: "color",
     type: AttributeType.Color,
@@ -54,6 +68,8 @@ export interface TextElementAttributes extends AttributeMap {
   outline: Color;
   opacity: number;
   visible: boolean;
+  yMargin: number;
+  xMargin: number;
 }
 
 export interface TextElementProperties extends AttributeMap {

--- a/src/core/prototypes/marks/text.ts
+++ b/src/core/prototypes/marks/text.ts
@@ -63,6 +63,8 @@ export class TextElementClass extends EmphasizableMarkClass<
     color: { r: 0, g: 0, b: 0 },
     opacity: 1,
     visible: true,
+    yMargin: 0,
+    xMargin: 0,
   };
 
   public static defaultProperties: Partial<TextElementProperties> = {
@@ -85,6 +87,8 @@ export class TextElementClass extends EmphasizableMarkClass<
     const attrs = <TextElementAttributes>this.state.attributes;
     attrs.x = 0;
     attrs.y = 0;
+    attrs.xMargin = 0;
+    attrs.yMargin = 0;
     attrs.text = "Text";
     attrs.fontFamily = defaultFont;
     attrs.fontSize = defaultFontSize;
@@ -128,8 +132,8 @@ export class TextElementClass extends EmphasizableMarkClass<
       metrics,
       props.alignment.x,
       props.alignment.y,
-      props.alignment.xMargin,
-      props.alignment.yMargin
+      attrs.xMargin || props.alignment.xMargin,
+      attrs.yMargin || props.alignment.yMargin
     );
     const p = cs.getLocalTransform(attrs.x + offset.x, attrs.y + offset.y);
     p.angle += props.rotation;
@@ -245,8 +249,8 @@ export class TextElementClass extends EmphasizableMarkClass<
       metrics,
       props.alignment.x,
       props.alignment.y,
-      props.alignment.xMargin,
-      props.alignment.yMargin
+      attrs.xMargin || props.alignment.xMargin,
+      attrs.yMargin || props.alignment.yMargin
     );
     const cx = dx + metrics.width / 2;
     const cy = dy + metrics.middle;
@@ -341,14 +345,25 @@ export class TextElementClass extends EmphasizableMarkClass<
             }
           ),
           props.alignment.x != "middle"
-            ? manager.inputNumber(
-                { property: "alignment", field: "xMargin" },
-                {
+            ? // ? manager.inputNumber(
+              //     { property: "alignment", field: "xMargin" },
+              //     {
+              //       updownTick: 1,
+              //       showUpdown: true,
+              //       label: "Margin",
+              //     }
+              //   )
+              manager.mappingEditor(strings.objects.text.margin, "xMargin", {
+                hints: { rangeNumber: [-1000, 1000] },
+                label: strings.objects.text.margin,
+                numberOptions: {
                   updownTick: 1,
                   showUpdown: true,
-                  label: "Margin",
-                }
-              )
+                  label: strings.objects.text.margin,
+                },
+                acceptKinds: [Specification.DataKind.Numerical],
+                defaultValue: 0,
+              })
             : null,
           manager.inputSelect(
             { property: "alignment", field: "y" },
@@ -365,14 +380,25 @@ export class TextElementClass extends EmphasizableMarkClass<
             }
           ),
           props.alignment.y != "middle"
-            ? manager.inputNumber(
-                { property: "alignment", field: "yMargin" },
-                {
+            ? // ? manager.inputNumber(
+              //     { property: "alignment", field: "yMargin" },
+              //     {
+              //       updownTick: 1,
+              //       showUpdown: true,
+              //       label: strings.objects.text.margin,
+              //     }
+              //   )
+              manager.mappingEditor(strings.objects.text.margin, "yMargin", {
+                hints: { rangeNumber: [-1000, 1000] },
+                label: strings.objects.text.margin,
+                numberOptions: {
                   updownTick: 1,
                   showUpdown: true,
                   label: strings.objects.text.margin,
-                }
-              )
+                },
+                acceptKinds: [Specification.DataKind.Numerical],
+                defaultValue: 0,
+              })
             : null,
           manager.inputNumber(
             { property: "rotation" },


### PR DESCRIPTION
1. It allows to map data to text margins to control label position from dataset. 
2. Breaks drag & drop feature for text positioning (need to fix it)
3. The range is from -100 to 100 no way to set limit except manual set or using existing scale.

![image](https://user-images.githubusercontent.com/10897951/131534647-6df09a65-1804-42ae-a87f-3cc18bfbea5a.png)

 Can be used to handle issue: https://github.com/microsoft/charticulator/issues/720 and https://youtu.be/J1Ukl6HY77I?t=2197