### PR TITLE
Add keyboard navigation over main UI elements

### DIFF
--- a/sass/components/buttons.scss
+++ b/sass/components/buttons.scss
@@ -28,7 +28,7 @@
 
 @mixin button-base($height) {
   border: none;
-  outline: none;
+  // outline: none;
   height: $height;
   line-height: $height;
   display: inline-block;
@@ -266,6 +266,8 @@
       @include icon-invert(0%);
       color: $gray-000;
     }
+    display: inline-block;
+    background: none;
   }
 
   &-row {
@@ -563,7 +565,7 @@
       flex: 1;
 
       border: none;
-      outline: none;
+      // outline: none;
     }
 
     .button-flat {

--- a/sass/components/canvas/attribute_editor.scss
+++ b/sass/components/canvas/attribute_editor.scss
@@ -1195,6 +1195,8 @@
         vertical-align: top;
         cursor: pointer;
         height: $line-height;
+        border: none;
+        background: none;
         border-radius: 2px;
 
         &.has-text {

--- a/src/app/components/buttons.tsx
+++ b/src/app/components/buttons.tsx
@@ -207,9 +207,15 @@ export class AppButton extends BaseButton<AppButtonProps> {
   public render() {
     return (
       <span
+        tabIndex={0}
         className="charticulator__button-menu-app charticulator-title__button"
         title={this.props.title}
         onClick={this._doClick}
+        onKeyPress={(e) => {
+          if (e.key === "Enter") {
+            this._doClick();
+          }
+        }}
       >
         <SVGImageIcon url={R.getSVGIcon("app-icon")} />
         <span className="el-text">{this.props.name || strings.app.name}</span>
@@ -230,12 +236,18 @@ export class MenuButton extends BaseButton<IconButtonProps> {
     if (props.text) {
       return (
         <span
+          tabIndex={0}
           className={classNames("charticulator__button-menu-text", [
             "is-disabled",
             this.props.disabled,
           ])}
           title={props.title}
           onClick={this._doClick}
+          onKeyPress={(e) => {
+            if (e.key === "Enter") {
+              this._doClick();
+            }
+          }}
         >
           <SVGImageIcon url={props.url} />
           <span className="el-text">{props.text}</span>
@@ -244,9 +256,15 @@ export class MenuButton extends BaseButton<IconButtonProps> {
     } else {
       return (
         <span
+          tabIndex={0}
           className="charticulator__button-menu"
           title={props.title}
           onClick={this._doClick}
+          onKeyPress={(e) => {
+            if (e.key === "Enter") {
+              this._doClick();
+            }
+          }}
         >
           <SVGImageIcon url={props.url} />
         </span>
@@ -261,35 +279,35 @@ export class ButtonFlat extends BaseButton<IconButtonProps> {
     if (props.url) {
       if (props.text) {
         return (
-          <span
+          <button
             className="charticulator__button-flat"
             title={props.title}
             onClick={this._doClick}
           >
             <SVGImageIcon url={props.url} />
             <span className="el-text">{props.text}</span>
-          </span>
+          </button>
         );
       } else {
         return (
-          <span
+          <button
             className="charticulator__button-flat"
             title={props.title}
             onClick={this._doClick}
           >
             <SVGImageIcon url={props.url} />
-          </span>
+          </button>
         );
       }
     } else {
       return (
-        <span
+        <button
           className="charticulator__button-flat"
           title={props.title}
           onClick={this._doClick}
         >
           <span className="el-text">{props.text}</span>
-        </span>
+        </button>
       );
     }
   }

--- a/src/app/controllers/popup_controller.tsx
+++ b/src/app/controllers/popup_controller.tsx
@@ -185,6 +185,7 @@ export interface PopupViewProps {
 
 export class PopupContainer extends React.Component<PopupViewProps, {}> {
   public token: EventSubscription;
+  private popupContainer: HTMLDivElement;
   constructor(props: PopupViewProps) {
     super(props);
     this.onKeyDown = this.onKeyDown.bind(this);
@@ -213,6 +214,11 @@ export class PopupContainer extends React.Component<PopupViewProps, {}> {
       this.forceUpdate();
     });
     window.addEventListener("keydown", this.onKeyDown);
+    setTimeout(() => {
+      if (this.popupContainer) {
+        this.popupContainer.focus();
+      }
+    }, 100);
   }
   public componentWillUnmount() {
     this.token.remove();
@@ -223,6 +229,7 @@ export class PopupContainer extends React.Component<PopupViewProps, {}> {
       const modal = this.props.controller.currentModal;
       return (
         <div
+          tabIndex={0}
           className="popup-container popup-container-modal"
           style={{
             position: "fixed",
@@ -235,6 +242,7 @@ export class PopupContainer extends React.Component<PopupViewProps, {}> {
           onMouseDown={() => {
             this.props.controller.reset();
           }}
+          ref={(r) => (this.popupContainer = r)}
         >
           {modal.element}
           {this.renderPopups()}
@@ -257,6 +265,7 @@ export class PopupContainer extends React.Component<PopupViewProps, {}> {
     } else {
       return (
         <div
+          tabIndex={0}
           className="popup-container"
           style={{
             position: "fixed",
@@ -266,6 +275,7 @@ export class PopupContainer extends React.Component<PopupViewProps, {}> {
             bottom: 0,
             pointerEvents: "all",
           }}
+          ref={(r) => (this.popupContainer = r)}
           onMouseDown={() => {
             this.props.controller.resetPopups();
           }}
@@ -298,6 +308,16 @@ export class PopupView extends React.Component<
   },
   {}
 > {
+  private popupContainer: HTMLDivElement;
+
+  public componentDidMount() {
+    setTimeout(() => {
+      if (this.popupContainer) {
+        this.popupContainer.focus();
+      }
+    }, 100);
+  }
+
   // eslint-disable-next-line
   public render() {
     const popup = this.props.context;
@@ -404,6 +424,8 @@ export class PopupView extends React.Component<
     }
     return (
       <div
+        tabIndex={0}
+        ref={(r) => (this.popupContainer = r)}
         className={
           this.props.className
             ? this.props.className + " popup-view-container"

--- a/src/app/views/canvas/mark_editor.tsx
+++ b/src/app/views/canvas/mark_editor.tsx
@@ -189,6 +189,7 @@ export class MarkEditorView extends ContextedComponent<
             <span className="glyph-tabs">
               {this.store.chart.glyphs.map((glyph) => (
                 <span
+                  tabIndex={0}
                   className={classNames("el-item", [
                     "is-active",
                     glyph == currentGlyph,
@@ -196,6 +197,11 @@ export class MarkEditorView extends ContextedComponent<
                   key={glyph._id}
                   onClick={() => {
                     this.dispatch(new Actions.SelectGlyph(null, glyph));
+                  }}
+                  onKeyPress={(e) => {
+                    if (e.key === "Enter") {
+                      this.dispatch(new Actions.SelectGlyph(null, glyph));
+                    }
                   }}
                 >
                   {glyph.properties.name}

--- a/src/app/views/dataset/data_field_selector.tsx
+++ b/src/app/views/dataset/data_field_selector.tsx
@@ -340,9 +340,20 @@ export class DataFieldSelector extends React.Component<
 
   public renderCandidate(item: DataFieldSelectorValueCandidate): JSX.Element {
     let elDerived: HTMLElement;
+    const onClick = (item: DataFieldSelectorValueCandidate) => {
+      if (item.selectable) {
+        this.selectItem(
+          item,
+          this.isValueEqual(this.state.currentSelection, item)
+            ? this.state.currentSelectionAggregation
+            : null
+        );
+      }
+    };
     return (
       <div className="el-column-item" key={item.table + item.expression}>
         <div
+          tabIndex={0}
           className={classNames(
             "el-field-item",
             [
@@ -353,18 +364,14 @@ export class DataFieldSelector extends React.Component<
             ],
             ["is-selectable", item.selectable]
           )}
-          onClick={
-            item.selectable
-              ? () => {
-                  this.selectItem(
-                    item,
-                    this.isValueEqual(this.state.currentSelection, item)
-                      ? this.state.currentSelectionAggregation
-                      : null
-                  );
-                }
-              : null
-          }
+          onClick={() => {
+            onClick(item);
+          }}
+          onKeyPress={(e) => {
+            if (e.key === "Enter") {
+              onClick(item);
+            }
+          }}
         >
           <SVGImageIcon url={R.getSVGIcon(kind2Icon[item.metadata.kind])} />
           <span className="el-text">{item.displayName}</span>
@@ -418,12 +425,18 @@ export class DataFieldSelector extends React.Component<
       <div className="charticulator__data-field-selector">
         {this.props.nullDescription ? (
           <div
+            tabIndex={0}
             className={classNames("el-field-item", "is-null", "is-selectable", [
               "is-active",
               !this.props.nullNotHighlightable &&
                 this.state.currentSelection == null,
             ])}
             onClick={() => this.selectItem(null)}
+            onKeyPress={(e) => {
+              if (e.key === "Enter") {
+                this.selectItem(null);
+              }
+            }}
           >
             {this.props.nullDescription}
           </div>

--- a/src/app/views/dataset/dataset_view.tsx
+++ b/src/app/views/dataset/dataset_view.tsx
@@ -376,6 +376,7 @@ export class ColumnView extends React.Component<
   ColumnViewProps,
   ColumnViewState
 > {
+  private columnRef: HTMLElement;
   constructor(props: ColumnViewProps) {
     super(props);
     this.state = {
@@ -446,42 +447,52 @@ export class ColumnView extends React.Component<
     displayLabel?: string
   ) {
     let anchor: HTMLDivElement;
+    const onClickHandler = () => {
+      if (!onColumnKindChanged) {
+        return;
+      }
+      globals.popupController.popupAt(
+        (context) => (
+          <PopupView key={label} context={context}>
+            <div>
+              <DropdownListView
+                selected={type}
+                list={getConvertableDataKind(type).map((type) => {
+                  return {
+                    name: type.toString(),
+                    text: type.toString(),
+                    url: R.getSVGIcon(kind2Icon[type]),
+                  };
+                })}
+                context={context}
+                onClick={(value: string) => {
+                  onColumnKindChanged(label, value);
+                }}
+                onClose={() => {
+                  anchor?.focus();
+                }}
+              />
+            </div>
+          </PopupView>
+        ),
+        {
+          anchor,
+          alignX: PopupAlignment.Outer,
+          alignY: PopupAlignment.StartInner,
+        }
+      );
+    };
     return (
       <div
+        tabIndex={0}
         key={label}
         className="click-handler"
         ref={(e) => (anchor = e)}
-        onClick={() => {
-          if (!onColumnKindChanged) {
-            return;
+        onClick={onClickHandler}
+        onKeyPress={(e) => {
+          if (e.key === "Enter") {
+            onClickHandler();
           }
-          globals.popupController.popupAt(
-            (context) => (
-              <PopupView key={label} context={context}>
-                <div>
-                  <DropdownListView
-                    selected={type}
-                    list={getConvertableDataKind(type).map((type) => {
-                      return {
-                        name: type.toString(),
-                        text: type.toString(),
-                        url: R.getSVGIcon(kind2Icon[type]),
-                      };
-                    })}
-                    context={context}
-                    onClick={(value: string) => {
-                      onColumnKindChanged(label, value);
-                    }}
-                  />
-                </div>
-              </PopupView>
-            ),
-            {
-              anchor,
-              alignX: PopupAlignment.Outer,
-              alignY: PopupAlignment.StartInner,
-            }
-          );
         }}
       >
         <DraggableElement

--- a/src/app/views/dataset/fluent_ui_data_field_selector.tsx
+++ b/src/app/views/dataset/fluent_ui_data_field_selector.tsx
@@ -340,9 +340,20 @@ export class DataFieldSelector extends React.Component<
 
   public renderCandidate(item: DataFieldSelectorValueCandidate): JSX.Element {
     let elDerived: HTMLElement;
+    const onClick = (item: DataFieldSelectorValueCandidate) => {
+      if (item.selectable) {
+        this.selectItem(
+          item,
+          this.isValueEqual(this.state.currentSelection, item)
+            ? this.state.currentSelectionAggregation
+            : null
+        );
+      }
+    };
     return (
       <div className="el-column-item" key={item.table + item.expression}>
         <div
+          tabIndex={0}
           className={classNames(
             "el-field-item",
             [
@@ -353,18 +364,12 @@ export class DataFieldSelector extends React.Component<
             ],
             ["is-selectable", item.selectable]
           )}
-          onClick={
-            item.selectable
-              ? () => {
-                  this.selectItem(
-                    item,
-                    this.isValueEqual(this.state.currentSelection, item)
-                      ? this.state.currentSelectionAggregation
-                      : null
-                  );
-                }
-              : null
-          }
+          onClick={() => onClick(item)}
+          onKeyPress={(e) => {
+            if (e.key === "Enter") {
+              onClick(item);
+            }
+          }}
         >
           <SVGImageIcon url={R.getSVGIcon(kind2Icon[item.metadata.kind])} />
           <span className="el-text">{item.displayName}</span>
@@ -420,12 +425,18 @@ export class DataFieldSelector extends React.Component<
       <div className="charticulator__data-field-selector">
         {this.props.nullDescription ? (
           <div
+            tabIndex={0}
             className={classNames("el-field-item", "is-null", "is-selectable", [
               "is-active",
               !this.props.nullNotHighlightable &&
                 this.state.currentSelection == null,
             ])}
             onClick={() => this.selectItem(null)}
+            onKeyPress={(e) => {
+              if (e.key === "Enter") {
+                this.selectItem(null);
+              }
+            }}
           >
             {this.props.nullDescription}
           </div>

--- a/src/app/views/file_view/index.tsx
+++ b/src/app/views/file_view/index.tsx
@@ -105,11 +105,18 @@ export class FileView extends React.Component<FileViewProps, FileViewState> {
     inputSaveChartName: HTMLInputElement;
   };
 
+  private buttonBack: HTMLElement;
   constructor(props: FileViewProps) {
     super(props);
     this.state = {
       currentTab: this.props.defaultTab || MainTabs.open,
     };
+  }
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.buttonBack?.focus();
+    }, 100);
   }
 
   public switchTab(currentTab: MainTabs) {
@@ -166,8 +173,15 @@ export class FileView extends React.Component<FileViewProps, FileViewState> {
         <div className="charticulator__file-view">
           <div className="charticulator__file-view-tabs">
             <div
+              ref={(r) => (this.buttonBack = r)}
+              tabIndex={0}
               className="el-button-back"
               onClick={() => this.props.onClose()}
+              onKeyPress={(e) => {
+                if (e.key === "Enter") {
+                  this.props.onClose();
+                }
+              }}
             >
               <SVGImageIcon url={R.getSVGIcon("toolbar/back")} />
             </div>
@@ -176,12 +190,18 @@ export class FileView extends React.Component<FileViewProps, FileViewState> {
                 <div key={index} className="el-sep" />
               ) : (
                 <div
+                  tabIndex={0}
                   key={index}
                   className={classNames("el-tab", [
                     "active",
                     this.state.currentTab == t,
                   ])}
                   onClick={() => this.switchTab(t)}
+                  onKeyPress={(e) => {
+                    if (e.key === "Enter") {
+                      this.switchTab(t);
+                    }
+                  }}
                 >
                   {strings.mainTabs[t]}
                 </div>

--- a/src/app/views/panels/object_list_editor.tsx
+++ b/src/app/views/panels/object_list_editor.tsx
@@ -46,9 +46,15 @@ export class ObjectListEditor extends ContextedComponent<{}, {}> {
     return (
       <div>
         <div
+          tabIndex={0}
           className={classNames("el-object-item", ["is-active", sel == null])}
           onClick={() => {
             this.dispatch(new Actions.ClearSelection());
+          }}
+          onKeyPress={(e) => {
+            if (e.key === "Enter") {
+              this.dispatch(new Actions.ClearSelection());
+            }
           }}
         >
           <SVGImageIcon
@@ -67,6 +73,7 @@ export class ObjectListEditor extends ContextedComponent<{}, {}> {
           {chart.elements.map((element) => {
             return (
               <div
+                tabIndex={0}
                 className={classNames("el-object-item", [
                   "is-active",
                   sel instanceof ChartElementSelection &&
@@ -74,6 +81,11 @@ export class ObjectListEditor extends ContextedComponent<{}, {}> {
                 ])}
                 onClick={() => {
                   this.dispatch(new Actions.SelectChartElement(element));
+                }}
+                onKeyPress={(e) => {
+                  if (e.key === "Enter") {
+                    this.dispatch(new Actions.SelectChartElement(element));
+                  }
                 }}
                 key={element._id}
               >
@@ -125,12 +137,18 @@ export class ObjectListEditor extends ContextedComponent<{}, {}> {
     return (
       <div key={glyph._id}>
         <div
+          tabIndex={0}
           className={classNames("el-object-item", [
             "is-active",
             sel instanceof GlyphSelection && sel.glyph == glyph,
           ])}
           onClick={() => {
             this.dispatch(new Actions.SelectGlyph(null, glyph));
+          }}
+          onKeyPress={(e) => {
+            if (e.key === "Enter") {
+              this.dispatch(new Actions.SelectGlyph(null, glyph));
+            }
           }}
         >
           <SVGImageIcon
@@ -151,6 +169,7 @@ export class ObjectListEditor extends ContextedComponent<{}, {}> {
             .map((mark) => {
               return (
                 <div
+                  tabIndex={0}
                   className={classNames("el-object-item", [
                     "is-active",
                     sel instanceof MarkSelection &&
@@ -160,6 +179,11 @@ export class ObjectListEditor extends ContextedComponent<{}, {}> {
                   key={mark._id}
                   onClick={() => {
                     this.dispatch(new Actions.SelectMark(null, glyph, mark));
+                  }}
+                  onKeyPress={(e) => {
+                    if (e.key === "Enter") {
+                      this.dispatch(new Actions.SelectMark(null, glyph, mark));
+                    }
                   }}
                 >
                   <SVGImageIcon

--- a/src/app/views/panels/widgets/controls/button.tsx
+++ b/src/app/views/panels/widgets/controls/button.tsx
@@ -21,7 +21,7 @@ export interface ButtonProps {
 export class Button extends React.Component<ButtonProps, {}> {
   public render() {
     return (
-      <span
+      <button
         className={classNames(
           "charticulator__widget-control-button",
           ["is-active", this.props.active],
@@ -46,7 +46,7 @@ export class Button extends React.Component<ButtonProps, {}> {
         {this.props.text ? (
           <span className="el-text">{this.props.text}</span>
         ) : null}
-      </span>
+      </button>
     );
   }
 }

--- a/src/app/views/panels/widgets/controls/select.tsx
+++ b/src/app/views/panels/widgets/controls/select.tsx
@@ -14,6 +14,7 @@ import { classNames } from "../../../../utils";
 export function DropdownListView(props: {
   list: { name: string; url?: string; text?: string; font?: string }[];
   onClick?: (name: string) => void;
+  onClose?: () => void;
   selected?: string;
   context: PopupContext;
 }) {
@@ -21,6 +22,7 @@ export function DropdownListView(props: {
     <ul className="dropdown-list">
       {props.list.map((item) => (
         <li
+          tabIndex={0}
           key={item.name}
           className={props.selected == item.name ? "is-active" : null}
           onClick={() => {
@@ -28,6 +30,16 @@ export function DropdownListView(props: {
               props.onClick(item.name);
             }
             props.context.close();
+            props.onClose?.();
+          }}
+          onKeyPress={(e) => {
+            if (e.key === "Enter") {
+              if (props.onClick) {
+                props.onClick(item.name);
+              }
+              props.context.close();
+              props.onClose?.();
+            }
           }}
         >
           {item.url != null ? <SVGImageIcon url={item.url} /> : null}


### PR DESCRIPTION
PR adds keyboard navigation over main elements.

![charticulator_keyboard_navigation](https://user-images.githubusercontent.com/10897951/135831427-dde32673-6da3-4c04-8538-baf43e700c8c.gif)

It is not complete work for full keyboard support. Some menu items still need custom event handlers. 