### PR TITLE
Add auto update property for boolean scales

### DIFF
--- a/src/app/stores/app_store.ts
+++ b/src/app/stores/app_store.ts
@@ -1412,6 +1412,25 @@ export class AppStore extends BaseStore {
           })
         );
       });
+
+      const resetOfScales = this.chart.scales.filter(
+        (other) => !legendScales.find((l) => l === other._id)
+      );
+
+      resetOfScales.forEach((scale) => {
+        if (scale.properties.autoDomainMax || scale.properties.autoDomainMin) {
+          updateScalesInternal(scale._id, chartElements, {
+            chart: this.chart,
+            glyph: null,
+          });
+          this.chart.glyphs.forEach((gl) =>
+            updateScalesInternal(scale._id, gl.marks, {
+              chart: this.chart,
+              glyph: gl,
+            })
+          );
+        }
+      });
     } catch (ex) {
       console.error("Updating of scales failed with error", ex);
     }

--- a/src/core/prototypes/scales/categorical.ts
+++ b/src/core/prototypes/scales/categorical.ts
@@ -530,6 +530,20 @@ export class CategoricalScaleBoolean extends ScaleClass<
       }
     }
     return [
+      manager.inputBoolean(
+        [
+          {
+            property: "autoDomainMin",
+          },
+          {
+            property: "autoDomainMax",
+          },
+        ],
+        {
+          type: "checkbox",
+          label: strings.objects.dataAxis.autoUpdateValues,
+        }
+      ),
       manager.sectionHeader("Boolean Mapping"),
       manager.row(
         null,


### PR DESCRIPTION
Introduces new property for boolean scales to handle case: https://github.com/microsoft/charticulator/issues/829

![image](https://user-images.githubusercontent.com/10897951/140986084-d3042d9e-7f4e-4b2b-8697-4e3f526f990f.png)

The update reuses current range of boolean values for new domain.
This behavior is different than in categorical scales for color.