### PR TITLE
Text background color attribute

### DIFF
--- a/src/app/renderer/index.tsx
+++ b/src/app/renderer/index.tsx
@@ -225,6 +225,52 @@ class TextOnPath extends React.PureComponent<{
   }
 }
 
+export function renderSVGDefs(element: Graphics.Element): JSX.Element {
+  if (!element) {
+    return null;
+  }
+  switch (element.type) {
+    case "text": {
+      const text = element as Graphics.Text;
+      if (text.style.backgroundColor) {
+        return (
+          <filter
+            x="0"
+            y="0"
+            width="1"
+            height="1"
+            id={text.style.backgroundColorId}
+          >
+            <feFlood
+              flood-color={renderColor(
+                text.style.backgroundColor,
+                text.style.colorFilter
+              )}
+              result="bg"
+            />
+            <feMerge>
+              <feMergeNode in="bg" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        );
+      } else {
+        return null;
+      }
+    }
+    case "group": {
+      const group = element as Graphics.Group;
+      return (
+        <>
+          {group.elements?.map((x) => {
+            return renderSVGDefs(x);
+          })}
+        </>
+      );
+    }
+  }
+}
+
 /** The method renders all chart elements in SVG document */
 // eslint-disable-next-line
 export function renderGraphicalElementSVG(
@@ -427,6 +473,9 @@ export function renderGraphicalElementSVG(
       const text = element as Graphics.Text;
       style.fontFamily = text.fontFamily;
       style.fontSize = text.fontSize + "px";
+      const filter = text.style.backgroundColorId
+        ? `url(#${text.style.backgroundColorId})`
+        : null;
       if (style.stroke != "none") {
         const style2 = shallowClone(style);
         style2.fill = style.stroke;
@@ -437,6 +486,7 @@ export function renderGraphicalElementSVG(
             style={style2}
             x={text.cx}
             y={-text.cy}
+            filter={filter}
           >
             {text.text}
           </text>
@@ -449,6 +499,7 @@ export function renderGraphicalElementSVG(
             style={style}
             x={text.cx}
             y={-text.cy}
+            filter={filter}
           >
             {text.text}
           </text>
@@ -468,6 +519,7 @@ export function renderGraphicalElementSVG(
             style={style}
             x={text.cx}
             y={-text.cy}
+            filter={filter}
           >
             {text.text}
           </text>

--- a/src/app/renderer/index.tsx
+++ b/src/app/renderer/index.tsx
@@ -473,7 +473,7 @@ export function renderGraphicalElementSVG(
       const text = element as Graphics.Text;
       style.fontFamily = text.fontFamily;
       style.fontSize = text.fontSize + "px";
-      const filter = text.style.backgroundColorId
+      const filter = text.style.backgroundColor
         ? `url(#${text.style.backgroundColorId})`
         : null;
       if (style.stroke != "none") {

--- a/src/app/views/canvas/chart_display.tsx
+++ b/src/app/views/canvas/chart_display.tsx
@@ -11,6 +11,7 @@ import { strings } from "../../../strings";
 import {
   GraphicalElementDisplay,
   renderGraphicalElementSVG,
+  renderSVGDefs,
 } from "../../renderer";
 
 export interface ChartDisplayViewProps {
@@ -120,6 +121,7 @@ export function renderChartToLocalString(
         xmlnsXlink="http://www.w3.org/1999/xlink"
         xmlSpace="preserve"
       >
+        <defs>{renderSVGDefs(graphics)}</defs>
         <g
           transform={`translate(${(width / 2).toFixed(6)},${(
             height / 2

--- a/src/app/views/canvas/chart_editor.tsx
+++ b/src/app/views/canvas/chart_editor.tsx
@@ -19,7 +19,7 @@ import {
 } from "../../../core";
 import { Actions, DragData } from "../../actions";
 import { DragContext, Droppable } from "../../controllers";
-import { GraphicalElementDisplay } from "../../renderer";
+import { GraphicalElementDisplay, renderSVGDefs } from "../../renderer";
 import {
   ChartElementSelection,
   AppStore,
@@ -1430,6 +1430,7 @@ export class ChartEditorView
             width={width}
             height={height}
           >
+            <defs>{renderSVGDefs(this.state.graphics)}</defs>
             <rect
               className="interaction-handler"
               ref="canvasInteraction"

--- a/src/container/chart_component.tsx
+++ b/src/container/chart_component.tsx
@@ -15,6 +15,7 @@ import {
   RenderGraphicalElementSVGOptions,
   DataSelection,
   GraphicalElementEventHandler,
+  renderSVGDefs,
 } from "../app/renderer";
 import { RenderEvents } from "../core/graphics";
 import { MappingType } from "../core/specification";
@@ -298,50 +299,53 @@ export class ChartComponent extends React.Component<
     renderOptions.selection = this.props.selection;
     const gfx = renderGraphicalElementSVG(this.state.graphics, renderOptions);
     const inner = (
-      <g
-        transform={`translate(${this.props.width / 2}, ${
-          this.props.height / 2
-        })`}
-      >
-        {this.props.onGlyphClick ? (
-          <rect
-            x={-this.props.width / 2}
-            y={-this.props.height / 2}
-            width={this.props.width}
-            height={this.props.height}
-            style={{
-              fill: "none",
-              pointerEvents: "all",
-              stroke: "none",
-            }}
-            onClick={() => {
-              this.props.onGlyphClick(null, null);
-            }}
-          />
-        ) : null}
-        {gfx}
-        {this.renderer.renderControls(
-          this.manager.chart,
-          this.manager.chartState,
-          {
-            centerX: 0,
-            centerY: 0,
-            scale: 1,
-          }
-        )}
-        {this.state.working ? (
-          <rect
-            x={-this.props.width / 2}
-            y={-this.props.height / 2}
-            width={this.props.width}
-            height={this.props.height}
-            style={{
-              fill: "rgba(0, 0, 0, 0.1)",
-              stroke: "none",
-            }}
-          />
-        ) : null}
-      </g>
+      <>
+        <defs>{renderSVGDefs(this.state.graphics)}</defs>
+        <g
+          transform={`translate(${this.props.width / 2}, ${
+            this.props.height / 2
+          })`}
+        >
+          {this.props.onGlyphClick ? (
+            <rect
+              x={-this.props.width / 2}
+              y={-this.props.height / 2}
+              width={this.props.width}
+              height={this.props.height}
+              style={{
+                fill: "none",
+                pointerEvents: "all",
+                stroke: "none",
+              }}
+              onClick={() => {
+                this.props.onGlyphClick(null, null);
+              }}
+            />
+          ) : null}
+          {gfx}
+          {this.renderer.renderControls(
+            this.manager.chart,
+            this.manager.chartState,
+            {
+              centerX: 0,
+              centerY: 0,
+              scale: 1,
+            }
+          )}
+          {this.state.working ? (
+            <rect
+              x={-this.props.width / 2}
+              y={-this.props.height / 2}
+              width={this.props.width}
+              height={this.props.height}
+              style={{
+                fill: "rgba(0, 0, 0, 0.1)",
+                stroke: "none",
+              }}
+            />
+          ) : null}
+        </g>
+      </>
     );
     switch (this.props.rootElement) {
       case "svg": {

--- a/src/core/common/math.ts
+++ b/src/core/common/math.ts
@@ -156,3 +156,7 @@ export function prettyNumber(x: number, digits: number = 8) {
     ?.toFixed(digits)
     .replace(/^([+-]?[0-9]*(\.[0-9]*[1-9]+)?)\.?0+$/, "$1");
 }
+
+export function getRandomNumber() {
+  window.crypto.getRandomValues(new Uint32Array(1))[0];
+}

--- a/src/core/common/math.ts
+++ b/src/core/common/math.ts
@@ -158,5 +158,7 @@ export function prettyNumber(x: number, digits: number = 8) {
 }
 
 export function getRandomNumber() {
-  window.crypto.getRandomValues(new Uint32Array(1))[0];
+  // crypto.getRandomValues(new Uint32Array(1))[0];
+  // eslint-disable-next-line
+  return +("" + Math.random()).slice(2);
 }

--- a/src/core/graphics/elements.ts
+++ b/src/core/graphics/elements.ts
@@ -69,6 +69,8 @@ export interface Style {
   colorFilter?: ColorFilter;
 
   fillColor?: Color;
+  backgroundColor?: Color;
+  backgroundColorId?: string;
   fillOpacity?: number;
 
   /** The opacity of this element */

--- a/src/core/prototypes/marks/text.attrs.ts
+++ b/src/core/prototypes/marks/text.attrs.ts
@@ -34,6 +34,12 @@ export const textAttributes: AttributeDescriptions = {
     solverExclude: true,
     defaultValue: null,
   },
+  backgroundColor: {
+    name: "backgroundColor",
+    type: AttributeType.Color,
+    solverExclude: true,
+    defaultValue: null,
+  },
   outline: {
     name: "outline",
     type: AttributeType.Color,
@@ -51,6 +57,7 @@ export interface TextElementAttributes extends AttributeMap {
   fontFamily: string;
   fontSize: number;
   color: Color;
+  backgroundColor: Color;
   outline: Color;
   opacity: number;
   visible: boolean;

--- a/src/core/prototypes/marks/text.attrs.ts
+++ b/src/core/prototypes/marks/text.attrs.ts
@@ -40,6 +40,12 @@ export const textAttributes: AttributeDescriptions = {
     solverExclude: true,
     defaultValue: null,
   },
+  backgroundColorFilterId: {
+    name: "backgroundColorFilterId",
+    type: AttributeType.Text,
+    solverExclude: true,
+    defaultValue: null,
+  },
   outline: {
     name: "outline",
     type: AttributeType.Color,
@@ -58,6 +64,7 @@ export interface TextElementAttributes extends AttributeMap {
   fontSize: number;
   color: Color;
   backgroundColor: Color;
+  backgroundColorFilterId: string;
   outline: Color;
   opacity: number;
   visible: boolean;

--- a/src/core/prototypes/marks/text.ts
+++ b/src/core/prototypes/marks/text.ts
@@ -61,6 +61,7 @@ export class TextElementClass extends EmphasizableMarkClass<
     fontFamily: defaultFont,
     fontSize: defaultFontSize,
     color: { r: 0, g: 0, b: 0 },
+    backgroundColor: { r: 0, g: 0, b: 0 },
     opacity: 1,
     visible: true,
   };
@@ -93,6 +94,7 @@ export class TextElementClass extends EmphasizableMarkClass<
       g: 0,
       b: 0,
     };
+    attrs.backgroundColor = null;
     attrs.visible = true;
     attrs.outline = null;
     attrs.opacity = 1;
@@ -116,6 +118,13 @@ export class TextElementClass extends EmphasizableMarkClass<
     const props = this.object.properties;
     if (!attrs.visible || !this.object.properties.visible) {
       return null;
+    }
+    let backgroundColorFilterId: string = null;
+    if (attrs.backgroundColor) {
+      // eslint-disable-next-line
+      backgroundColorFilterId = `text-color-filter-${("" + Math.random()).slice(
+        2
+      )}`;
     }
     const metrics = Graphics.TextMeasurer.Measure(
       attrs.text,
@@ -150,6 +159,8 @@ export class TextElementClass extends EmphasizableMarkClass<
             {
               strokeColor: attrs.outline,
               fillColor: attrs.color,
+              backgroundColor: attrs.backgroundColor,
+              backgroundColorId: backgroundColorFilterId,
               opacity: attrs.opacity,
               ...this.generateEmphasisStyle(empasized),
             }
@@ -167,6 +178,8 @@ export class TextElementClass extends EmphasizableMarkClass<
         {
           strokeColor: attrs.outline,
           fillColor: attrs.color,
+          backgroundColor: attrs.backgroundColor,
+          backgroundColorId: backgroundColorFilterId,
           opacity: attrs.opacity,
           ...this.generateEmphasisStyle(empasized),
         }
@@ -390,6 +403,11 @@ export class TextElementClass extends EmphasizableMarkClass<
         },
         [
           manager.mappingEditor(strings.objects.color, "color", {}),
+          manager.mappingEditor(
+            strings.objects.background,
+            "backgroundColor",
+            {}
+          ),
           manager.mappingEditor(strings.objects.outline, "outline", {}),
           manager.mappingEditor(strings.objects.opacity, "opacity", {
             hints: { rangeNumber: [0, 1] },

--- a/src/core/prototypes/marks/text.ts
+++ b/src/core/prototypes/marks/text.ts
@@ -95,7 +95,6 @@ export class TextElementClass extends EmphasizableMarkClass<
       b: 0,
     };
     attrs.backgroundColor = null;
-    // eslint-disable-next-line
     attrs.backgroundColorFilterId = `text-color-filter-${getRandomNumber()}`;
     attrs.visible = true;
     attrs.outline = null;
@@ -122,7 +121,6 @@ export class TextElementClass extends EmphasizableMarkClass<
       return null;
     }
     if (!attrs.backgroundColorFilterId) {
-      // eslint-disable-next-line
       attrs.backgroundColorFilterId = `text-color-filter-${getRandomNumber()}`;
     }
     const metrics = Graphics.TextMeasurer.Measure(

--- a/src/core/prototypes/marks/text.ts
+++ b/src/core/prototypes/marks/text.ts
@@ -61,7 +61,6 @@ export class TextElementClass extends EmphasizableMarkClass<
     fontFamily: defaultFont,
     fontSize: defaultFontSize,
     color: { r: 0, g: 0, b: 0 },
-    backgroundColor: { r: 0, g: 0, b: 0 },
     opacity: 1,
     visible: true,
   };
@@ -95,6 +94,10 @@ export class TextElementClass extends EmphasizableMarkClass<
       b: 0,
     };
     attrs.backgroundColor = null;
+    // eslint-disable-next-line
+    attrs.backgroundColorFilterId = `text-color-filter-${(
+      "" + Math.random()
+    ).slice(2)}`;
     attrs.visible = true;
     attrs.outline = null;
     attrs.opacity = 1;
@@ -119,12 +122,11 @@ export class TextElementClass extends EmphasizableMarkClass<
     if (!attrs.visible || !this.object.properties.visible) {
       return null;
     }
-    let backgroundColorFilterId: string = null;
-    if (attrs.backgroundColor) {
+    if (!attrs.backgroundColorFilterId) {
       // eslint-disable-next-line
-      backgroundColorFilterId = `text-color-filter-${("" + Math.random()).slice(
-        2
-      )}`;
+      attrs.backgroundColorFilterId = `text-color-filter-${(
+        "" + Math.random()
+      ).slice(2)}`;
     }
     const metrics = Graphics.TextMeasurer.Measure(
       attrs.text,
@@ -160,7 +162,7 @@ export class TextElementClass extends EmphasizableMarkClass<
               strokeColor: attrs.outline,
               fillColor: attrs.color,
               backgroundColor: attrs.backgroundColor,
-              backgroundColorId: backgroundColorFilterId,
+              backgroundColorId: attrs.backgroundColorFilterId,
               opacity: attrs.opacity,
               ...this.generateEmphasisStyle(empasized),
             }
@@ -179,7 +181,7 @@ export class TextElementClass extends EmphasizableMarkClass<
           strokeColor: attrs.outline,
           fillColor: attrs.color,
           backgroundColor: attrs.backgroundColor,
-          backgroundColorId: backgroundColorFilterId,
+          backgroundColorId: attrs.backgroundColorFilterId,
           opacity: attrs.opacity,
           ...this.generateEmphasisStyle(empasized),
         }
@@ -403,11 +405,9 @@ export class TextElementClass extends EmphasizableMarkClass<
         },
         [
           manager.mappingEditor(strings.objects.color, "color", {}),
-          manager.mappingEditor(
-            strings.objects.background,
-            "backgroundColor",
-            {}
-          ),
+          manager.mappingEditor(strings.objects.background, "backgroundColor", {
+            defaultValue: null,
+          }),
           manager.mappingEditor(strings.objects.outline, "outline", {}),
           manager.mappingEditor(strings.objects.opacity, "opacity", {
             hints: { rangeNumber: [0, 1] },
@@ -463,6 +463,19 @@ export class TextElementClass extends EmphasizableMarkClass<
         },
         type: Specification.AttributeType.Color,
         default: rgbToHex(this.state.attributes.color),
+      });
+    }
+    if (
+      this.object.mappings.backgroundColor &&
+      this.object.mappings.backgroundColor.type === MappingType.value
+    ) {
+      properties.push({
+        objectID: this.object._id,
+        target: {
+          attribute: "backgroundColor",
+        },
+        type: Specification.AttributeType.Color,
+        default: null,
       });
     }
     if (

--- a/src/core/prototypes/marks/text.ts
+++ b/src/core/prototypes/marks/text.ts
@@ -10,6 +10,7 @@ import {
   splitStringByNewLine,
   rgbToHex,
   Geometry,
+  getRandomNumber,
 } from "../../common";
 import * as Graphics from "../../graphics";
 import { ConstraintSolver } from "../../solver";
@@ -95,9 +96,7 @@ export class TextElementClass extends EmphasizableMarkClass<
     };
     attrs.backgroundColor = null;
     // eslint-disable-next-line
-    attrs.backgroundColorFilterId = `text-color-filter-${(
-      "" + Math.random()
-    ).slice(2)}`;
+    attrs.backgroundColorFilterId = `text-color-filter-${getRandomNumber()}`;
     attrs.visible = true;
     attrs.outline = null;
     attrs.opacity = 1;
@@ -124,9 +123,7 @@ export class TextElementClass extends EmphasizableMarkClass<
     }
     if (!attrs.backgroundColorFilterId) {
       // eslint-disable-next-line
-      attrs.backgroundColorFilterId = `text-color-filter-${(
-        "" + Math.random()
-      ).slice(2)}`;
+      attrs.backgroundColorFilterId = `text-color-filter-${getRandomNumber()}`;
     }
     const metrics = Graphics.TextMeasurer.Measure(
       attrs.text,

--- a/src/core/prototypes/marks/textbox.attrs.ts
+++ b/src/core/prototypes/marks/textbox.attrs.ts
@@ -40,6 +40,18 @@ export const textboxAttributes: AttributeDescriptions = {
     solverExclude: true,
     defaultValue: null,
   },
+  backgroundColor: {
+    name: "backgroundColor",
+    type: AttributeType.Color,
+    solverExclude: true,
+    defaultValue: null,
+  },
+  backgroundColorFilterId: {
+    name: "backgroundColorFilterId",
+    type: AttributeType.Text,
+    solverExclude: true,
+    defaultValue: null,
+  },
   outline: {
     name: "outline",
     type: AttributeType.Color,

--- a/src/core/prototypes/marks/textbox.ts
+++ b/src/core/prototypes/marks/textbox.ts
@@ -10,6 +10,7 @@ import {
   replaceSymbolByNewLine,
   rgbToHex,
   splitStringByNewLine,
+  getRandomNumber,
 } from "../../common";
 import * as Graphics from "../../graphics";
 import { splitByWidth } from "../../graphics";
@@ -97,9 +98,7 @@ export class TextboxElementClass extends EmphasizableMarkClass<
     };
     attrs.backgroundColor = null;
     // eslint-disable-next-line
-    attrs.backgroundColorFilterId = `text-color-filter-${(
-      "" + Math.random()
-    ).slice(2)}`;
+    attrs.backgroundColorFilterId = `text-color-filter-${getRandomNumber()}`;
     attrs.visible = true;
     attrs.outline = null;
     attrs.opacity = 1;
@@ -352,9 +351,7 @@ export class TextboxElementClass extends EmphasizableMarkClass<
     }
     if (!attrs.backgroundColorFilterId) {
       // eslint-disable-next-line
-      attrs.backgroundColorFilterId = `text-color-filter-${(
-        "" + Math.random()
-      ).slice(2)}`;
+      attrs.backgroundColorFilterId = `text-color-filter-${getRandomNumber()}`;
     }
     const metrics = Graphics.TextMeasurer.Measure(
       attrs.text,

--- a/src/core/prototypes/marks/textbox.ts
+++ b/src/core/prototypes/marks/textbox.ts
@@ -70,7 +70,6 @@ export class TextboxElementClass extends EmphasizableMarkClass<
     fontFamily: defaultFont,
     fontSize: defaultFontSize,
     color: { r: 0, g: 0, b: 0 },
-    backgroundColor: { r: 0, g: 0, b: 0 },
     opacity: 1,
     visible: true,
   };
@@ -97,6 +96,10 @@ export class TextboxElementClass extends EmphasizableMarkClass<
       b: 0,
     };
     attrs.backgroundColor = null;
+    // eslint-disable-next-line
+    attrs.backgroundColorFilterId = `text-color-filter-${(
+      "" + Math.random()
+    ).slice(2)}`;
     attrs.visible = true;
     attrs.outline = null;
     attrs.opacity = 1;
@@ -263,11 +266,9 @@ export class TextboxElementClass extends EmphasizableMarkClass<
         },
         [
           manager.mappingEditor(strings.objects.color, "color", {}),
-          manager.mappingEditor(
-            strings.objects.background,
-            "backgroundColor",
-            {}
-          ),
+          manager.mappingEditor(strings.objects.background, "backgroundColor", {
+            defaultValue: null,
+          }),
           manager.mappingEditor(strings.objects.outline, "outline", {}),
           manager.mappingEditor(strings.objects.opacity, "opacity", {
             hints: { rangeNumber: [0, 1] },
@@ -348,6 +349,12 @@ export class TextboxElementClass extends EmphasizableMarkClass<
       attrs.opacity == 0
     ) {
       return Graphics.makeGroup([]);
+    }
+    if (!attrs.backgroundColorFilterId) {
+      // eslint-disable-next-line
+      attrs.backgroundColorFilterId = `text-color-filter-${(
+        "" + Math.random()
+      ).slice(2)}`;
     }
     const metrics = Graphics.TextMeasurer.Measure(
       attrs.text,
@@ -813,6 +820,7 @@ export class TextboxElementClass extends EmphasizableMarkClass<
     ];
   }
 
+  // eslint-disable-next-line
   public getTemplateParameters(): TemplateParameters {
     const properties = [];
     if (
@@ -865,6 +873,19 @@ export class TextboxElementClass extends EmphasizableMarkClass<
         },
         type: Specification.AttributeType.Color,
         default: rgbToHex(this.state.attributes.color),
+      });
+    }
+    if (
+      this.object.mappings.backgroundColor &&
+      this.object.mappings.backgroundColor.type === MappingType.value
+    ) {
+      properties.push({
+        objectID: this.object._id,
+        target: {
+          attribute: "backgroundColor",
+        },
+        type: Specification.AttributeType.Color,
+        default: null,
       });
     }
     if (

--- a/src/core/prototypes/marks/textbox.ts
+++ b/src/core/prototypes/marks/textbox.ts
@@ -70,6 +70,7 @@ export class TextboxElementClass extends EmphasizableMarkClass<
     fontFamily: defaultFont,
     fontSize: defaultFontSize,
     color: { r: 0, g: 0, b: 0 },
+    backgroundColor: { r: 0, g: 0, b: 0 },
     opacity: 1,
     visible: true,
   };
@@ -95,6 +96,7 @@ export class TextboxElementClass extends EmphasizableMarkClass<
       g: 0,
       b: 0,
     };
+    attrs.backgroundColor = null;
     attrs.visible = true;
     attrs.outline = null;
     attrs.opacity = 1;
@@ -261,6 +263,11 @@ export class TextboxElementClass extends EmphasizableMarkClass<
         },
         [
           manager.mappingEditor(strings.objects.color, "color", {}),
+          manager.mappingEditor(
+            strings.objects.background,
+            "backgroundColor",
+            {}
+          ),
           manager.mappingEditor(strings.objects.outline, "outline", {}),
           manager.mappingEditor(strings.objects.opacity, "opacity", {
             hints: { rangeNumber: [0, 1] },

--- a/src/core/prototypes/marks/textbox.ts
+++ b/src/core/prototypes/marks/textbox.ts
@@ -97,7 +97,6 @@ export class TextboxElementClass extends EmphasizableMarkClass<
       b: 0,
     };
     attrs.backgroundColor = null;
-    // eslint-disable-next-line
     attrs.backgroundColorFilterId = `text-color-filter-${getRandomNumber()}`;
     attrs.visible = true;
     attrs.outline = null;
@@ -350,7 +349,6 @@ export class TextboxElementClass extends EmphasizableMarkClass<
       return Graphics.makeGroup([]);
     }
     if (!attrs.backgroundColorFilterId) {
-      // eslint-disable-next-line
       attrs.backgroundColorFilterId = `text-color-filter-${getRandomNumber()}`;
     }
     const metrics = Graphics.TextMeasurer.Measure(

--- a/src/core/prototypes/plot_segments/axis.ts
+++ b/src/core/prototypes/plot_segments/axis.ts
@@ -9,6 +9,7 @@ import {
   fillDefaults,
   Geometry,
   getFormat,
+  getRandomNumber,
   replaceSymbolByNewLine,
   replaceSymbolByTab,
   rgbToHex,
@@ -48,6 +49,8 @@ import React = require("react");
 
 export const defaultAxisStyle: Specification.Types.AxisRenderingStyle = {
   tickColor: { r: 0, g: 0, b: 0 },
+  tickTextBackgroudColor: null,
+  tickTextBackgroudColorId: null,
   showTicks: true,
   lineColor: { r: 0, g: 0, b: 0 },
   fontFamily: defaultFont,
@@ -109,6 +112,8 @@ export class AxisRenderer {
     } else {
       this.style = fillDefaultAxisStyle(deepClone(style));
     }
+    this.style.tickTextBackgroudColorId =
+      "axis-tick-filter-" + getRandomNumber();
     return this;
   }
 
@@ -593,6 +598,8 @@ export class AxisRenderer {
               style.fontSize,
               {
                 fillColor: style.tickColor,
+                backgroundColor: style.tickTextBackgroudColor,
+                backgroundColorId: style.tickTextBackgroudColorId,
               }
             );
             lines.push(text);
@@ -623,6 +630,8 @@ export class AxisRenderer {
               style.fontSize,
               {
                 fillColor: style.tickColor,
+                backgroundColor: style.tickTextBackgroudColor,
+                backgroundColorId: style.tickTextBackgroudColorId,
               },
               this.plotSegment && this.dataFlow
                 ? {
@@ -664,6 +673,8 @@ export class AxisRenderer {
             style.fontSize,
             {
               fillColor: style.tickColor,
+              backgroundColor: style.tickTextBackgroudColor,
+              backgroundColorId: style.tickTextBackgroudColorId,
             },
             this.plotSegment && this.dataFlow
               ? {
@@ -724,6 +735,8 @@ export class AxisRenderer {
               style.fontSize,
               {
                 fillColor: style.tickColor,
+                backgroundColor: style.tickTextBackgroudColor,
+                backgroundColorId: style.tickTextBackgroudColorId,
               },
               this.plotSegment && this.dataFlow
                 ? {
@@ -793,6 +806,8 @@ export class AxisRenderer {
                 style.fontSize,
                 {
                   fillColor: style.tickColor,
+                  backgroundColor: style.tickTextBackgroudColor,
+                  backgroundColorId: style.tickTextBackgroudColorId,
                 },
                 this.plotSegment && this.dataFlow
                   ? {
@@ -850,6 +865,8 @@ export class AxisRenderer {
                 style.fontSize,
                 {
                   fillColor: style.tickColor,
+                  backgroundColor: style.tickTextBackgroudColor,
+                  backgroundColorId: style.tickTextBackgroudColorId,
                 },
                 this.plotSegment && this.dataFlow
                   ? {
@@ -1066,6 +1083,8 @@ export class AxisRenderer {
             style.fontSize,
             {
               fillColor: style.tickColor,
+              backgroundColor: style.tickTextBackgroudColor,
+              backgroundColorId: style.tickTextBackgroudColorId,
             }
           );
           lines.push(gt);
@@ -1094,6 +1113,8 @@ export class AxisRenderer {
           makeLine(0, 0, 0, style.tickSize * side, lineStyle),
           makeText(textX, textY, tick.label, style.fontFamily, style.fontSize, {
             fillColor: style.tickColor,
+            backgroundColor: style.tickTextBackgroudColor,
+            backgroundColorId: style.tickTextBackgroudColorId,
           }),
         ]);
 
@@ -1139,6 +1160,8 @@ export class AxisRenderer {
         makeLine(0, 0, 0, -style.tickSize * side, lineStyle),
         makeText(textX, textY, tick.label, style.fontFamily, style.fontSize, {
           fillColor: style.tickColor,
+          backgroundColor: style.tickTextBackgroudColor,
+          backgroundColorId: style.tickTextBackgroudColorId,
         }),
       ]);
 
@@ -1402,6 +1425,16 @@ export function buildAxisAppearanceWidgets(
               {
                 label: strings.objects.axes.tickColor,
                 labelKey: strings.objects.axes.tickColor,
+              }
+            ),
+            manager.inputColor(
+              {
+                property: axisProperty,
+                field: ["style", "tickTextBackgroudColor"],
+              },
+              {
+                label: strings.objects.axes.tickTextBackgroudColor,
+                labelKey: strings.objects.axes.tickTextBackgroudColor,
               }
             ),
             manager.inputFormat(

--- a/src/core/specification/types.ts
+++ b/src/core/specification/types.ts
@@ -95,6 +95,8 @@ export interface AxisRenderingStyle extends AttributeMap {
   fontFamily: string;
   fontSize: number;
   tickSize: number;
+  tickTextBackgroudColor: Color;
+  tickTextBackgroudColorId: string;
   wordWrap: boolean;
   gridlineStyle: StrokeStyle;
   gridlineColor: Color;

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -426,6 +426,7 @@ export const strings = {
       dataExpressions: "Data Expressions",
       lineColor: "Line Color",
       tickColor: "Tick Label Color",
+      tickTextBackgroudColor: "Tick background color",
       showTickLine: "Show Tick Line",
       verticalText: "Vertical text",
       offSet: "Offset",

--- a/src/tests/unit/charts/bar-chart.json
+++ b/src/tests/unit/charts/bar-chart.json
@@ -2302,6 +2302,8 @@
                 "g": 0,
                 "b": 0
               },
+              "backgroundColor": null,
+              "backgroundColorFilterId": null,
               "visible": true,
               "outline": null,
               "opacity": 1

--- a/src/tests/unit/charts/side-by-side.json
+++ b/src/tests/unit/charts/side-by-side.json
@@ -2936,6 +2936,8 @@
                 "g": 0,
                 "b": 0
               },
+              "backgroundColor": null,
+              "backgroundColorFilterId": null,
               "visible": true,
               "outline": null,
               "opacity": 1


### PR DESCRIPTION
Background color attribute for text object. Implementation for https://github.com/microsoft/charticulator/issues/831

![image](https://user-images.githubusercontent.com/10897951/142729081-54a00c01-ba59-44b5-be03-56c025411db6.png)

Axis ticks:
![image](https://user-images.githubusercontent.com/10897951/142729845-30ef0e73-6e22-4707-98cb-d1c0b6eb4b97.png)

Background color was set by SVG filter.