### PR TITLE
Disable preact for extensions

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,12 +124,12 @@ module.exports = (env, { mode }) => {
       resolve: {
         alias: {
           resources: __dirname + "/resources",
-          react: "preact-compat",
-          "react-dom": "preact-compat",
+          // react: "preact-compat",
+          // "react-dom": "preact-compat",
           // Not necessary unless you consume a module using `createClass`
-          "create-react-class": "preact-compat/lib/create-react-class",
+          // "create-react-class": "preact-compat/lib/create-react-class",
           // Not necessary unless you consume a module requiring `react-dom-factories`
-          "react-dom-factories": "preact-compat/lib/react-dom-factories"
+          // "react-dom-factories": "preact-compat/lib/react-dom-factories"
         }
       },
       plugins


### PR DESCRIPTION
The temp solution to handle issue https://github.com/microsoft/charticulator/issues/865

Build of old Charticulator visual by [extension](https://github.com/microsoft/charticulator-extensions) with full react library works.

@bongshin @MrRamka 
I want to suggest to disable preact for extensions. Current Appsource visual already uses full react lib. We aren't losing in weight of the visual with compression and without editor is still compact. (300 KB compressed and 900 KB without compression)