### PR TITLE
Minor: issue with categorical tick data and tick format, rid of first and last ticks

### DIFF
--- a/src/app/stores/app_store.ts
+++ b/src/app/stores/app_store.ts
@@ -1989,6 +1989,9 @@ export class AppStore extends BaseStore {
               );
             }
           }
+          //reset tick data for categorical data
+          dataBinding.tickFormat = null;
+          dataBinding.tickDataExpression = null;
 
           break;
         case Specification.DataKind.Numerical:

--- a/src/core/prototypes/plot_segments/axis.ts
+++ b/src/core/prototypes/plot_segments/axis.ts
@@ -1514,7 +1514,7 @@ export function buildAxisAppearanceWidgets(
               },
               {
                 label: strings.objects.axes.lineColor,
-                labelKey: strings.objects.axes.lineColor,
+                labelKey: `line-color-${axisProperty}`,
                 allowNull: true,
               }
             ),
@@ -1549,7 +1549,7 @@ export function buildAxisAppearanceWidgets(
               },
               {
                 label: strings.objects.axes.tickColor,
-                labelKey: strings.objects.axes.tickColor,
+                labelKey: `tick-color-${axisProperty}`,
                 allowNull: true,
               }
             ),
@@ -1560,7 +1560,7 @@ export function buildAxisAppearanceWidgets(
               },
               {
                 label: strings.objects.axes.tickTextBackgroudColor,
-                labelKey: strings.objects.axes.tickTextBackgroudColor,
+                labelKey: `tick-text-background-color-${axisProperty}`,
                 allowNull: true,
               }
             ),

--- a/src/core/prototypes/plot_segments/axis.ts
+++ b/src/core/prototypes/plot_segments/axis.ts
@@ -615,9 +615,10 @@ export class AxisRenderer {
       g.elements.push(makeLine(x1, y1, x2, y2, lineStyle));
     }
     // Ticks
-    const ticksData = this.ticks.map((x) => x.position);
-    const visibleTicks = ticksData.concat([rangeMin, rangeMax]);
-
+    const visibleTicks = this.ticks.map((x) => x.position);
+    if (style.showBaseline) {
+      visibleTicks.push(rangeMin, rangeMax);
+    }
     if (style.showTicks) {
       for (const tickPosition of visibleTicks) {
         const tx = x + tickPosition * cos;

--- a/src/core/prototypes/plot_segments/plot_segment.ts
+++ b/src/core/prototypes/plot_segments/plot_segment.ts
@@ -157,7 +157,7 @@ export abstract class PlotSegmentClass<
             },
             {
               label: strings.objects.color,
-              labelKey: strings.objects.color,
+              labelKey: `gridline-color-${axisProperty}`,
             }
           ),
           manager.inputNumber(


### PR DESCRIPTION
- Rid of first and last ticks: https://github.com/microsoft/charticulator/issues/914
![image](https://user-images.githubusercontent.com/41204824/155522595-dca06263-86a3-4c85-bc5b-8f34a079479e.png)


- Fixed the issue with color picker incorrect display in Plot Segment 
- Fixed the issue with categorical tick data and tick format