### PR TITLE
1026: Render axis gridlines even axis is invisible

### DIFF
--- a/src/core/prototypes/plot_segments/region_2d/cartesian.ts
+++ b/src/core/prototypes/plot_segments/region_2d/cartesian.ts
@@ -433,7 +433,7 @@ export class CartesianPlotSegment extends PlotSegmentClass<
     const attrs = this.state.attributes;
     const props = this.object.properties;
 
-    if (props.xData && props.xData.visible) {
+    if (props.xData) {
       const axisRenderer = new AxisRenderer().setAxisDataBinding(
         props.xData,
         0,
@@ -452,7 +452,7 @@ export class CartesianPlotSegment extends PlotSegmentClass<
       );
     }
 
-    if (props.yData && props.yData.visible) {
+    if (props.yData) {
       const axisRenderer = new AxisRenderer().setAxisDataBinding(
         props.yData,
         0,


### PR DESCRIPTION
Fix for [1026](https://github.com/microsoft/charticulator/issues/1026)