### PR TITLE
Keep the search bar on top in attributes panel

### DIFF
--- a/src/app/main_view.tsx
+++ b/src/app/main_view.tsx
@@ -245,7 +245,7 @@ export class MainView extends React.Component<MainViewProps, MainViewState> {
             {this.state.attributeViewMaximized ? null : (
               <MinimizablePane
                 title={strings.mainView.attributesPaneltitle}
-                scroll={true}
+                scroll={false}
                 onMaximize={() =>
                   this.setState({ attributeViewMaximized: true })
                 }
@@ -353,7 +353,7 @@ export class MainView extends React.Component<MainViewProps, MainViewState> {
               ) : null}
               {this.state.attributeViewMaximized ? (
                 <FloatingPanel
-                  scroll={true}
+                  scroll={false}
                   peerGroup="panels"
                   title={strings.mainView.attributesPaneltitle}
                   onClose={() =>

--- a/src/app/views/panels/attribute_panel.tsx
+++ b/src/app/views/panels/attribute_panel.tsx
@@ -190,7 +190,18 @@ export class AttributePanel extends React.Component<
             {manager.searchInput({
               placeholder: "Search",
             })}
-            {manager.vertical(...objectClass.getAttributePanelWidgets(manager))}
+            {manager.scrollList(
+              [
+                manager.vertical(
+                  ...objectClass.getAttributePanelWidgets(manager)
+                ),
+              ],
+              {
+                styles: {
+                  overflowX: "hidden",
+                },
+              }
+            )}
           </section>
         </div>
       );

--- a/src/app/views/panels/widgets/controls/fluentui_customized_components.tsx
+++ b/src/app/views/panels/widgets/controls/fluentui_customized_components.tsx
@@ -128,7 +128,7 @@ export const FluentGroupedList = styled.div<{ marginLeft?: number }>`
     margin-left: ${({ marginLeft }) =>
       marginLeft != null ? marginLeft : "25px"};
     margin-right: 15px;
-    min-width: 270px;
+    min-width: 255px;
   }
 
   .ms-List-surface .ms-List-cell .ms-List-cell:last-child {


### PR DESCRIPTION
Fix for https://github.com/microsoft/charticulator/issues/1011

![image](https://user-images.githubusercontent.com/10897951/189501423-dd28ecb8-91a5-4acd-8300-86339a41db34.png)

TODO: calculate height of scrollable area to use available space